### PR TITLE
Relevant manual notes taken from the Fedora wiki page: 

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -70,6 +70,10 @@ python-backports-ssl_match_hostname:
     status: dropped
     note: |
         Included in Python 3.2
+python-BeautifulSoup:
+    status: dropped
+    note: |
+        Replacement: `python-beautifulsoup4`
 python-bunch:
     status: dropped
     note: |
@@ -125,6 +129,11 @@ python-openid:
     status: dropped
     note: |
       Replacement: `python3-openid`
+python-webob1.1:
+    status: dropped
+    note: |
+        This is a backwards compatibility package.  The regular package has python3 support.
+        Replacement: `python-webob`
 samba:
     links:
         bug: https://bugzilla.redhat.com/show_bug.cgi?id=1014589


### PR DESCRIPTION
http://fedoraproject.org/wiki/Python3

A long time ago dmalcolm setup a wiki page to track porting status and a script would run through the package collection scrapping information to populate it.  There were also fields for manual notes.  @ralphbean has been running the script since dmalcolm moved on to other things.

I've just gone through the wiki page to find all the manual notes that still seemed to be relevant and made this pull request for them.