### PR TITLE
Add more upstream data for other packages maintained by the Obnam upstream

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -21,9 +21,14 @@ obnam: &obnam
   note: |
     Author is "not really ready to accept patches".
     See the [mailing list post](http://listmaster.pepperfish.net/pipermail/obnam-dev-obnam.org/2015-October/000238.html).
-python-ttystatus: *obnam
+genbackupdata: *obnam
+python-cliapp: *obnam
+python-coverage-test-runner: *obnam
 python-larch: *obnam
 python-tracing: *obnam
+python-ttystatus: *obnam
+seivot: *obnam
+summain: *obnam
 lorem-ipsum-generator:
   status: idle
 python-yubico:

--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -21,6 +21,7 @@ obnam: &obnam
   note: |
     Author is "not really ready to accept patches".
     See the [mailing list post](http://listmaster.pepperfish.net/pipermail/obnam-dev-obnam.org/2015-October/000238.html).
+cmdtest: *obnam
 genbackupdata: *obnam
 python-cliapp: *obnam
 python-coverage-test-runner: *obnam


### PR DESCRIPTION
While the packages that Obnam depends on have been marked, there are other related packages by Lars Wirzenius; they should inherit the Obnam upstream status too.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fedora-python/portingdb/19)
<!-- Reviewable:end -->
