### PR TITLE
Add the upstream information of "python-peewee" package.

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -90,3 +90,12 @@ autotrash:
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282044
     repo: https://github.com/bneijt/autotrash/
+python-peewee:
+  status: released
+  links:
+    repo: https://github.com/coleifer/peewee
+    travis-ci: https://travis-ci.org/coleifer/peewee
+  note:
+    Since the version 2.1.0, upstream supports Python 3. Also, the code base is
+    actively tested against Python 3.2 and later (follow the 'travis-ci' link
+    for details).


### PR DESCRIPTION
[Since April 2013](https://github.com/coleifer/peewee/issues/163#issuecomment-15696845), the peewee project started to support Python 3.X.

Here I marked `python-peewee` package as "released" (with additional info on the support status).