### PR TITLE
Mark python-statsd as "released".

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -104,10 +104,9 @@ python-statsd:
   status: released
   links:
     repo: https://github.com/jsocol/pystatsd
-    travis-ci: https://travis-ci.org/jsocol/pystatsd
   note:
     Upstream has already fixed the code to support Python 3. The unit tests are
-    also running against 3.X.
+    also [running against 3.X](https://travis-ci.org/jsocol/pystatsd).
 python-tracing: *obnam
 python-ttystatus: *obnam
 python-yubico:

--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -100,6 +100,14 @@ python-pyldap:
     Should eventually be merged back into python-ldap.
 python-shove:
   status: released
+python-statsd:
+  status: released
+  links:
+    repo: https://github.com/jsocol/pystatsd
+    travis-ci: https://travis-ci.org/jsocol/pystatsd
+  note:
+    Upstream has already fixed the code to support Python 3. The unit tests are
+    also running against 3.X.
 python-tracing: *obnam
 python-ttystatus: *obnam
 python-yubico:


### PR DESCRIPTION
Mark `python-statsd` as "released".

Here is the brief summary of the support status:

* Since [this pull request](https://github.com/jsocol/pystatsd/pull/12/files), the developers started to support Python 3. 
* [On their Travis CI](https://travis-ci.org/jsocol/pystatsd) , Python 3.2, 3.3 and 3.4 are actively tested against.