### PR TITLE
tweepy confirmed python3 ready (and tox-tested) upstream by @decause

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -35,6 +35,12 @@ createrepo_c:
 cmdtest: *obnam
 copr-cli:
   status: in-progress
+tweepy:
+  status: released
+  links:
+      homepage: https://pypi.python.org/pypi/tweepy/
+      repo: https://github.com/tweepy/tweepy
+  note: "reported with <3 by decause"
 python-flask-mako:
   status: released
   links:


### PR DESCRIPTION
![screenshot from 2015-11-14 15-22-35](https://cloud.githubusercontent.com/assets/427420/11165672/bc1ec23a-8ae3-11e5-8b41-354d83f6732f.png)
