### PR TITLE
info updated about pylibmc

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -177,6 +177,12 @@ python-pyldap:
     repo: https://github.com/pyldap/pyldap
   note: |
     Should eventually be merged back into python-ldap.
+python-pylibmc:
+  status: released
+  note: |
+    Upstream does support python3; Fedora package needs to be updated
+  links:
+    repo: https://github.com/lericson/pylibmc
 python-pyprintr:
   status: released
   links:


### PR DESCRIPTION
The upstream supports Python 3. I have checked the package by running tests. Fedora needs to be updated about this package