### PR TITLE
python-bash8 added

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -120,6 +120,8 @@ python-backports-ssl_match_hostname:
     status: dropped
     note: |
         Included in Python 3.2
+python-bash8:
+    status: released
 python-BeautifulSoup:
     status: dropped
     note: |


### PR DESCRIPTION
It produces python2-bash8 and python3-bash8. It's quite strange that python2-bash8 requires both python(abi) = 2.7 and /usr/bin/python3.