### PR TITLE
update python-oauth2 status

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -210,6 +210,10 @@ python-openid:
 python-os-testr:
     links:
         bug: https://bugzilla.redhat.com/show_bug.cgi?id=1279704
+python-oauth2:
+    status: idle
+    links:
+        bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282225
 python-subprocess32:
     status: dropped
     note: |

--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -176,6 +176,12 @@ python-mwclient:
     should be included in mwclient-0.8 when its finally out.
 python-nss:
   status: in-progress
+python-oauth2:
+  status: released
+  link:
+    repo: https://github.com/joestump/python-oauth2
+  note:
+    Latest 1.9.0 upstream supports Python 3.
 python-peewee:
   status: released
   links:


### PR DESCRIPTION
Upstream already supported Python 3.