### PR TITLE
Note that python-urlgrabber is being looked at

### DIFF
--- a/data/porters.yaml
+++ b/data/porters.yaml
@@ -10,5 +10,8 @@ libldb:
     status: released
     links:
         repo: https://git.samba.org/?p=metze/samba/wip.git;a=shortlog;h=refs/heads/master3-python
+python-urlgrabber:
+    status: in-progress
+    note: FAS:salimma looking at doing a port, will check with mstuchli for status of existing port attempt
 samba:
     priority: high


### PR DESCRIPTION
Looking at the code for now, @sYnfo will check with his colleague that IHRC was working on a port earlier

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fedora-python/portingdb/83)
<!-- Reviewable:end -->
