### PR TITLE
Add python-django-countries

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -123,6 +123,11 @@ python-django-celery:
   links:
     repo: https://github.com/celery/celery
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282109
+python-django-countries:
+  status: released
+  links:
+    repo: https://github.com/SmileyChris/django-countries/
+    bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282237
 python-django-extra-form-fields:
   status: released
   links:


### PR DESCRIPTION
I've tested that python-django-countries is compatible with python3 and opened a RHBZ ticket in order to inform the maintainer.

// Giulio (jpigface on IRC | juliuxpigface on FAS)