### PR TITLE
autotrash spec file fixed

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -11,7 +11,7 @@ obnam: &obnam
 autotrash:
   status: released
   note: |
-    Upstream does support python3; Fedora package needs to be updated
+    Spec file fixed; package rebuilt
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282044
     repo: https://github.com/bneijt/autotrash/


### PR DESCRIPTION
Now it's ready and it coming do updates-testing.
I think it should not be considered as dependency for https://bugzilla.redhat.com/show_bug.cgi?id=1282146#c1