### PR TITLE
Mention porting effort upstream for libfreenect.

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -78,9 +78,11 @@ libldb:
   status: in-progress
 libfreenect:
   status: in-progress
-  note: Claimed fixed in 0.5.2, but build system is not updated to search for Python 3
+  note: |
+    Opened new PR fixing issues; most examples require an update for OpenCV though,
+    but shouldn't affect actual compatibility.
   links:
-    bug: https://github.com/OpenKinect/libfreenect/issues/429
+    bug: https://github.com/OpenKinect/libfreenect/issues/458
 libtalloc:
   status: released
 libtdb:


### PR DESCRIPTION
Should have Python 3 support once merged & released.