### PR TITLE
python-xlib added

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -345,6 +345,10 @@ python-tracing: *obnam
 python-ttystatus: *obnam
 python-xlwt:
   status: released
+python-xlib:
+  status: in-progress
+  links:
+    bug: http://sourceforge.net/p/python-xlib/mailman/python-xlib-users/thread/1447862425.2461.3.camel%40gmail.com/#msg34629506
 python-yubico:
   status: released
 rapid-photo-downloader:


### PR DESCRIPTION
We are discussing how to create an official port to Python 3 on the mailing list.
There are some old patches and an unofficial Python 3 only port.

Here's my full report: https://titanpad.com/ATHhAiShv8