### PR TITLE
Update kernel-tests bug tracking URL

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -47,7 +47,7 @@ kernel-tests:
     status: in-progress
     links:
         repo: https://git.fedorahosted.org/cgit/kernel-tests.git
-        bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282133
+        bug: https://github.com/rodrigc/kernel-tests/issues
     note: |
         [rodrigc](https://github.com/rodrigc) is submitting fixes in [his repo](https://github.com/rodrigc/kernel-tests)
 gstreamer-python:


### PR DESCRIPTION
The kernel-tests scripts are somewhat disorganized because of the lack of an easy-to-use place to contribute upstream. The bug reported on Bugzilla was closed by a member of the Fedora kernel team because they said Bugzilla was not the appropriate place to report it, and instead encouraged posting to the mailing list, which I did. In the meanwhile, because of discussion in #fedora-python, it seems like rodrigc's repo is the best place for bug tracking as of now, without a central place upstream to manage the code.