### PR TITLE
Update status from iotop, autotrash, powerline and python-ZConfig

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -7,6 +7,9 @@
 anjuta:
     links:
         bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282116
+autotrash:
+    links:
+        bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282044
 boost:
     nonblocking: true
     note: |
@@ -42,6 +45,9 @@ exo:
 gdal:
     links:
         bug: https://bugzilla.redhat.com/show_bug.cgi?id=1213629
+iotop:
+    links:
+        bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282262
 kernel-tests:
     status: in-progress
     links:
@@ -80,6 +86,9 @@ m2crypto:
     nonblocking: true
     note: |
       Suggested replacement: `python-cryptography`
+powerline:
+    links:
+        bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282487
 pycairo:
     status: dropped
     note: |
@@ -234,6 +243,9 @@ python-os-testr:
 python-oauth2:
     links:
         bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282225
+python-pelican:
+    links:
+        bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282229
 python-pdfrw:
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282219
@@ -263,6 +275,9 @@ python-webtest1.3:
       ported to the current version of the library as part of porting to
       python3.
       Replacement: `python-webtest`
+python-ZConfig:
+    links:
+        bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282153
 samba:
     links:
         bug: https://bugzilla.redhat.com/show_bug.cgi?id=1014589


### PR DESCRIPTION
Packages now support python3 in rawhide

https://bugzilla.redhat.com/show_bug.cgi?id=1282146