### PR TITLE
Note abiword upstream is already Python 3 compatible.

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -6,7 +6,15 @@ obnam: &obnam
     Author is "not really ready to accept patches".
     See the [mailing list post](http://listmaster.pepperfish.net/pipermail/obnam-dev-obnam.org/2015-October/000238.html).
 
-# Please keep everything from here on akphabetized
+# Please keep everything from here on alphabetized
+
+abiword:
+  status: released
+  note: |
+      There's only one upstream file and it's a tiny stub. It's fully
+      compatible with Python 3 by default. (There's an unrelated issue
+      where PyGObject >= 3.18 emits a warning due to a failure to explicitly
+      specify a GTK API version. A bug report has been submitted to address that.)
 
 autotrash:
   status: released


### PR DESCRIPTION
I took a look at abiword (since it was near the top of the list, and I use it), and there's nothing to do at their end, so I've noted that. I'll open a bug in Red Hat's Bugzilla to move the python-abiword package to Python 3.