### PR TITLE
Note abiword upstream status

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -6,7 +6,16 @@ obnam: &obnam
     Author is "not really ready to accept patches".
     See the [mailing list post](http://listmaster.pepperfish.net/pipermail/obnam-dev-obnam.org/2015-October/000238.html).
 
-# Please keep everything from here on akphabetized
+# Please keep everything from here on alphabetized
+
+abiword:
+  note: |
+    The single Abi.py file provided upstream is a tiny stub that has no
+    compatibility issues. However, the make file components supplied to
+    install it contain a command line invocation of Python that's not
+    compatible.
+  links:
+    bug: http://bugzilla.abisource.com/show_bug.cgi?id=13746
 
 autotrash:
   status: released


### PR DESCRIPTION
I had a look at abiword (since it was near the top of the list, and I use it), so I've noted that. I've also opened a bug in Red Hat's Bugzilla to move the python-abiword package to Python 3. (The only porting issue can be fixed with a trivial patch downstream if need be.)