### PR TITLE
Unported Turbogears and TurboGears2 dependencies

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -147,6 +147,15 @@ python-docs:
     status: dropped
     note: |
         Replacement: `python3-docs`
+python-elixir:
+    status: dropped
+    note: |
+      Suggested replacement: `python3-sqlalchemy` has a builtin declarative
+      layer now.  Porting to that is most likely the best route forward.
+      `python-elixir` had some work done in its source repository to support
+      python3 but that was never released.  The source repository has since
+      been taken down so that work has been lost and upstream appears to
+      have died.
 python-instant:
     note: |
       spec file updated and built in rawhide by [fab](http://fabian-affolter.ch).
@@ -161,6 +170,12 @@ python-kerberos:
     status: dropped
     note: |
       Suggested replacement: `python-gssapi`
+python-kid:
+    status: dropped
+    note: |
+      Suggested replacement: `python-genshi`
+      Not a drop-in replacement but genshi's templating language is based on
+      kid's so it's the closest thing.  python-kid is dead upstream.
 python-krbV:
     status: dropped
     note: |
@@ -206,6 +221,21 @@ python-os-testr:
 python-pdfrw:
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282219
+python-peak-rules:
+  status: dropped
+  note: |
+    In April of 2015 upstream did some work to port this to python3 but that
+    work hasn't been completed or pushed to a release package yet.  This
+    package is not currently needed by any Fedora package that is to be ported
+    to python3 so no one on the Fedora side has had a desire to work on porting
+    for upstream.  Note that python-peak-rules and its dependencies interact
+    with some low-level pieces of python so porting work is different than
+    other packages.
+python-prioritized_methods:
+  status: dropped
+  note: |
+    See the notes for [python-peak-rules](http://portingdb-encukou.rhcloud.com/pkg/python-peak-rules/)
+    which this depends upon.
 python-pyudev:
   nonblocking: true
   note: |
@@ -215,6 +245,36 @@ python-subprocess32:
     note: |
       This is a backport of the subprocess module in python-3.2 to python2.
       For python3 code, just use subprocess from the stdlib.
+python-tgmochikit:
+    status: dropped
+    note: |
+      Dead upstream.  Part of TurboGears-1.  Port to TurboGears2 and a newer
+      javascript framework like jquery.
+python-toscawidgets:
+    status: dropped
+    note: |
+      Suggested Replacement: python-tw2-core (toscawidgets2).  Porting will be needed as it
+      is not a drop in replacement.
+python-turbocheetah:
+    status: dropped
+    note: |
+      Dead upstream   Part of TurboGears-1.  Port to TurboGears2 and a newer
+      templating library like jinja2.
+python-turbojson:
+    status: dropped
+    note: |
+      Dead upstream.  Part of TurboGears-1.  Port to TurboGears2 where this
+      isn't needed.
+python-turbokid:
+    status: dropped
+    note: |
+      Dead upstream.  Part of TurboGears-1.  Port to TurboGears2 and
+      a different templating language (genshi is similar to kid) where this
+      isn't needed.
+python-tw-forms:
+    status: dropped
+    note: |
+      Suggested Replacement: python-tw2-forms
 python-twiggy:
     links:
         bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282112
@@ -244,6 +304,11 @@ tracer:
     note: |
       Upstream seems to have support for python3.
       The fedora packager is also upstream.
+TurboGears:
+    statue: dropped
+    note: |
+      TurboGears-1 is not seeing further upstream development.
+      Suggested Replacement: TurboGears2 (Similar API but porting will be needed)
 will-crash:
     status: released  # (exception)
     note: |

--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -273,6 +273,10 @@ python-flask-mako:
       homepage: https://pypi.python.org/pypi/Flask-Mako/
       repo: https://github.com/benselme/flask-mako
   note: "reported with <3 by decause"
+python-formencode:
+  status: released
+  note: |
+    Upstream has support from 1.3.0.  Some incompatibilities with earlier versions exist.
 python-genmsg:
   status: released
   repo: https://github.com/ros/genmsg
@@ -314,6 +318,10 @@ python-oauth2:
     repo: https://github.com/joestump/python-oauth2
   note:
     Latest 1.9.0 upstream supports Python 3.
+python-paste-script:
+  status: released
+  note: |
+    Python3 support was added in 2.0.0 with numerous python3-related bugfixes through 2.0.2
 python-pdfrw:
   status: released
   links:
@@ -347,6 +355,12 @@ python-progressbar:
   status: released
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282094
+python-repoze-who-plugins-sa:
+  links:
+    repo: https://github.com/repoze/repoze.who-sqlalchemy/commits/master
+  note: |
+    Python3 support (as well as resistance to timing attacks!) may be
+    unreleased but committed to upstream source repository
 python-restsh:
   status: released
   links:
@@ -355,6 +369,10 @@ python-restsh:
     Upstream claims to have support for Python 3.2. Fedora package needs to be updated.
 python-retask:
   status: released
+python-routes:
+  status: released
+  note: |
+    Upstream python3 support as of 2.2
 python-rows:
   status: in-progress
   links:
@@ -370,17 +388,25 @@ python-SimpleCV:
   note: Also blocked by need to port to opencv3 (since opencv2 doesn't support Python 3)
   links:
     bug: https://github.com/sightmachine/SimpleCV/pull/677
+python-sqlobject:
+  status: released
+  note: |
+    Upstream python3 support is present in 3.0.0a1dev (official snapshot uploaded to pypi).
 python-fedmsg-meta-fedora-infrastructure:
   status: released
 python-statsd:
   status: released
   links:
     repo: https://github.com/jsocol/pystatsd
-  note:
+  note: |
     Upstream has already fixed the code to support Python 3. The unit tests are
     also [running against 3.X](https://travis-ci.org/jsocol/pystatsd).
 python-tracing: *obnam
 python-ttystatus: *obnam
+python-tw2-forms:
+  status: released
+  note: |
+    Upstream support from 2.2.0 on
 python-xlwt:
   status: released
 python-xlib:
@@ -418,6 +444,10 @@ speedtest-cli:
     Once the 5.100 upstream (with patches) is released, patched spec file will
     go in for rawhide
 summain: *obnam
+TurboGears2:
+  status: released
+  note: |
+    The latest release supports python3
 tweepy:
   status: released
   links:


### PR DESCRIPTION
@encukou @ralphbean Updated the fedora and upstream yaml files with information on unported packages in the TG1 and TG2 stack.  Aiming for TG1 to be dropped and TG2 to be updated to have python3 support.