### PR TITLE
Python2-only packages with known python3 support upstream are now labeled 'mispackaged'.

### DIFF
--- a/data/fedora.json
+++ b/data/fedora.json
@@ -170,7 +170,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "NFStest": {
     "deps": [
@@ -814,7 +814,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "abrt": {
     "deps": [
@@ -1330,7 +1330,7 @@
         "libpython2.7.so.1.0()(64bit)": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "ascend": {
     "deps": [
@@ -1758,7 +1758,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "babel": {
     "deps": [
@@ -1833,7 +1833,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "barman": {
     "deps": [
@@ -1855,7 +1855,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "barry": {
     "deps": [],
@@ -1925,7 +1925,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "beakerlib": {
     "deps": [
@@ -2034,7 +2034,7 @@
         "python = 2.7.11-4.fc24": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "bind": {
     "deps": [],
@@ -2294,7 +2294,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "boom": {
     "deps": [
@@ -2348,7 +2348,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "bpython": {
     "deps": [
@@ -2399,7 +2399,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "brltty": {
     "deps": [
@@ -2577,7 +2577,7 @@
         "python = 2.7.11-4.fc24": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "bzr": {
     "deps": [
@@ -2851,7 +2851,7 @@
         "python-argparse = 2.7.11-4.fc24": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "ccnet": {
     "deps": [
@@ -3300,7 +3300,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "codemod": {
     "deps": [
@@ -3931,7 +3931,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "dap2rpm": {
     "deps": [
@@ -4610,7 +4610,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "docker-compose": {
     "deps": [
@@ -4649,7 +4649,7 @@
         "/usr/bin/python2": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "doge": {
     "deps": [
@@ -5506,7 +5506,7 @@
         "/usr/bin/python": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "fedora-productimg-server": {
     "deps": [
@@ -5573,7 +5573,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "fedrepos": {
     "deps": [
@@ -6457,7 +6457,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "ganglia": {
     "deps": [
@@ -7081,7 +7081,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "glib2": {
     "deps": [],
@@ -7534,7 +7534,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "gnome-weather": {
     "deps": [],
@@ -7905,7 +7905,7 @@
         "python2 = 2.7.11": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "gpsd": {
     "deps": [
@@ -8115,7 +8115,7 @@
         "/usr/bin/python": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "grib_api": {
     "deps": [
@@ -10061,7 +10061,7 @@
         "/usr/bin/python": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "koji-containerbuild": {
     "deps": [
@@ -11262,7 +11262,7 @@
         "python3 = 3.5.1-7.fc25": 3
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "libssh2-python": {
     "deps": [
@@ -11280,7 +11280,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "libstoragemgmt": {
     "deps": [
@@ -11317,7 +11317,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "libsvm": {
     "deps": [
@@ -11392,7 +11392,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "libuser": {
     "deps": [
@@ -11771,7 +11771,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "lrbd": {
     "deps": [
@@ -13425,7 +13425,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "officeparser": {
     "deps": [],
@@ -14441,7 +14441,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "pacrunner": {
     "deps": [],
@@ -15814,7 +15814,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "py3status": {
     "deps": [
@@ -15832,7 +15832,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "py4j": {
     "deps": [
@@ -16201,7 +16201,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "pyexiv2": {
     "deps": [
@@ -16738,7 +16738,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "pyliblo": {
     "deps": [
@@ -16870,7 +16870,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "pynac": {
     "deps": [
@@ -17160,7 +17160,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "pyrasite": {
     "deps": [
@@ -17300,7 +17300,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "pyserial": {
     "deps": [
@@ -17760,7 +17760,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-Lightbox": {
     "deps": [
@@ -17825,7 +17825,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-PyGithub": {
     "deps": [
@@ -18522,7 +18522,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-acme": {
     "deps": [
@@ -18731,7 +18731,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-altgraph": {
     "deps": [
@@ -19029,7 +19029,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-apsw": {
     "deps": [
@@ -19615,7 +19615,7 @@
         "python(abi) = 3.5": 3
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-batchhttp": {
     "deps": [
@@ -19844,7 +19844,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-bitlyapi": {
     "deps": [
@@ -19866,7 +19866,7 @@
         "python(abi) = 3.5": 3
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-bitmath": {
     "deps": [
@@ -20062,7 +20062,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-boto": {
     "deps": [
@@ -20150,7 +20150,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-bucky": {
     "deps": [
@@ -20366,7 +20366,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-castellan": {
     "deps": [
@@ -20560,7 +20560,7 @@
         "python-argparse = 2.7.11-4.fc24": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-ceilometermiddleware": {
     "deps": [
@@ -20859,7 +20859,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-cliapp": {
     "deps": [
@@ -21002,7 +21002,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-cloudfiles": {
     "deps": [
@@ -21077,7 +21077,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-cmigemo": {
     "deps": [
@@ -22295,7 +22295,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-ajax-selects": {
     "deps": [
@@ -22346,7 +22346,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-appconf": {
     "deps": [
@@ -22413,7 +22413,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-babel": {
     "deps": [
@@ -22587,7 +22587,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-devserver": {
     "deps": [
@@ -22660,7 +22660,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-extra-form-fields": {
     "deps": [
@@ -22784,7 +22784,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-helpdesk": {
     "deps": [
@@ -22802,7 +22802,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-keyedcache": {
     "deps": [
@@ -22879,7 +22879,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-notification": {
     "deps": [
@@ -22952,7 +22952,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-post_office": {
     "deps": [
@@ -23012,7 +23012,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-pyscss": {
     "deps": [
@@ -23118,7 +23118,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-roa": {
     "deps": [
@@ -23149,7 +23149,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-sahara": {
     "deps": [
@@ -23179,7 +23179,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-sekizai": {
     "deps": [
@@ -23213,7 +23213,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-django-setuptest": {
     "deps": [
@@ -23442,7 +23442,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-dmidecode": {
     "deps": [
@@ -24089,7 +24089,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-epub": {
     "deps": [
@@ -24491,7 +24491,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-feedparser": {
     "deps": [
@@ -24718,7 +24718,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-flask-cache": {
     "deps": [
@@ -24762,7 +24762,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-flask-images": {
     "deps": [
@@ -24841,7 +24841,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-flask-multistatic": {
     "deps": [
@@ -24908,7 +24908,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-flask-restful": {
     "deps": [
@@ -25135,7 +25135,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-flock": {
     "deps": [
@@ -25469,7 +25469,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-fsmonitor": {
     "deps": [
@@ -25486,7 +25486,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-fuckit": {
     "deps": [
@@ -26267,7 +26267,7 @@
         "python(abi) = 3.5": 3
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-grapefruit": {
     "deps": [
@@ -26285,7 +26285,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-greenlet": {
     "deps": [
@@ -27178,7 +27178,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-ironic-inspector-client": {
     "deps": [
@@ -27429,7 +27429,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-jinja2": {
     "deps": [
@@ -28114,7 +28114,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-landslide": {
     "deps": [
@@ -28214,7 +28214,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-ldap3": {
     "deps": [
@@ -28377,7 +28377,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-libcnml": {
     "deps": [
@@ -29146,7 +29146,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-meliae": {
     "deps": [
@@ -29623,7 +29623,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-mpmath": {
     "deps": [
@@ -29889,7 +29889,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-mysql": {
     "deps": [
@@ -30579,7 +30579,7 @@
         "python-argparse = 2.7.11-4.fc24": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-novaclient-os-networks": {
     "deps": [
@@ -32125,7 +32125,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-pefile": {
     "deps": [
@@ -33091,7 +33091,7 @@
         "python-argparse = 2.7.11-4.fc24": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-py9p": {
     "deps": [
@@ -33114,7 +33114,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-pyactivetwo": {
     "deps": [
@@ -33262,7 +33262,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-pycallgraph": {
     "deps": [
@@ -33280,7 +33280,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-pycha": {
     "deps": [
@@ -33737,7 +33737,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-pymod2pkg": {
     "deps": [
@@ -33754,7 +33754,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-pymongo": {
     "deps": [
@@ -33909,7 +33909,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-pyphen": {
     "deps": [
@@ -34203,7 +34203,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-pysaml2": {
     "deps": [
@@ -34231,7 +34231,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-pysb": {
     "deps": [
@@ -34312,7 +34312,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-pytest-cache": {
     "deps": [
@@ -35785,7 +35785,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-rply": {
     "deps": [
@@ -35946,7 +35946,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-s3transfer": {
     "deps": [
@@ -36199,7 +36199,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-seaborn": {
     "deps": [
@@ -36276,7 +36276,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-sep": {
     "deps": [
@@ -36523,7 +36523,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-sieve": {
     "deps": [
@@ -36574,7 +36574,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-simplegeneric": {
     "deps": [
@@ -36667,7 +36667,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-simplevisor": {
     "deps": [
@@ -36720,7 +36720,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-singledispatch": {
     "deps": [
@@ -37017,7 +37017,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-socksipychain": {
     "deps": [
@@ -37846,7 +37846,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-sybase": {
     "deps": [
@@ -38088,7 +38088,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-taskw": {
     "deps": [
@@ -38208,7 +38208,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-testify": {
     "deps": [
@@ -38230,7 +38230,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-testing.postgresql": {
     "deps": [
@@ -38352,7 +38352,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-tftpy": {
     "deps": [
@@ -38719,7 +38719,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-traceback2": {
     "deps": [
@@ -38906,7 +38906,7 @@
         "python-argparse = 2.7.11-4.fc24": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-ttystatus": {
     "deps": [
@@ -38993,7 +38993,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-tw-forms": {
     "deps": [
@@ -39269,7 +39269,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-twisted-conch": {
     "deps": [
@@ -39660,7 +39660,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-uri-templates": {
     "deps": [
@@ -39799,7 +39799,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-vatnumber": {
     "deps": [
@@ -39817,7 +39817,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-vcrpy": {
     "deps": [
@@ -39922,7 +39922,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-virtualenv": {
     "deps": [
@@ -39994,7 +39994,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-visual": {
     "deps": [
@@ -40812,7 +40812,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-xgoogle": {
     "deps": [
@@ -41326,7 +41326,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-zope-datetime": {
     "deps": [
@@ -41426,7 +41426,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-zope-i18n": {
     "deps": [
@@ -41447,7 +41447,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-zope-i18nmessageid": {
     "deps": [
@@ -41501,7 +41501,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-zope-processlifetime": {
     "deps": [
@@ -41541,7 +41541,7 @@
         "python(abi) = 3.5": 3
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "python-zope-schema": {
     "deps": [
@@ -41953,7 +41953,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "pyttsx": {
     "deps": [
@@ -43524,7 +43524,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "samtools": {
     "deps": [],
@@ -48479,7 +48479,7 @@
         "python2 = 2.7.11": 2
       }
     },
-    "status": "idle"
+    "status": "mispackaged"
   },
   "wklej": {
     "deps": [

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -253,6 +253,8 @@ class Py3QueryCommand(dnf.cli.Command):
                                           'ERRATA', 'NEXTRELEASE')
                 if r.get('status') == 'idle' and bug.status != 'NEW':
                     r['status'] = 'in-progress'
+                elif r.get('status') == 'idle' and bug.status == 'NEW':
+                    r['status'] = "mispackaged"
 
         # Print out output
 


### PR DESCRIPTION
Includes an updated fedora.json file.