### PR TITLE
Removed 'status: released' tag of most of packages.

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -76,18 +76,14 @@ abiword:
   links:
     bug: http://bugzilla.abisource.com/show_bug.cgi?id=13746
 alacarte:
-  status: released
   links:
     repo: https://github.com/GNOME/alacarte/
 autotrash:
-  status: released
   note: |
     Spec file fixed; package rebuilt
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282044
     repo: https://github.com/bneijt/autotrash/
-babel:
-  status: released
 boom:
   links:
     bug: https://github.com/tarekziade/boom/pull/52
@@ -106,7 +102,6 @@ cloudtoserver:
     bug: https://github.com/fedora-cloud/cloudtoserver/pull/6
 cmdtest: *obnam
 createrepo_c:
-  status: released
   links:
     bug: https://github.com/rpm-software-management/createrepo_c/pull/43
   note: |
@@ -124,11 +119,9 @@ diffuse:
     planning significant refactoring work, and it seems unlikely porting would
     occur prior to that.
 exo:
-  status: released
   note: |
     Upstream does not use Python at all, it's Fedora only dependency.
 fabric:
-  status: released
   links:
     bug: https://github.com/fabric/fabric/issues/1378
   note: |
@@ -140,7 +133,6 @@ fabric:
     [released the fork to pypi](https://pypi.python.org/pypi/Fabric3).
     It can be installed with `pip install Fabric3`.
 fail2ban:
-  status: released
   links:
       repo: https://github.com/fail2ban/fail2ban
       bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282498
@@ -150,18 +142,14 @@ fife:
     links:
         bug: https://github.com/fifengine/fifengine/issues/631
 fonts-tweak-tool:
-  status: released
   links:
     repo: https://bitbucket.org/tagoh/fonts-tweak-tool/src
 freeipa:
   links:
       homepage: https://www.freeipa.org
       repo: https://git.fedorahosted.org/cgit/freeipa.git
-gdal:
-  status: released
 genbackupdata: *obnam
 glances:
-    status: released
     links:
       repo: https://github.com/nicolargo/glances
       bug: https://bugzilla.redhat.com/show_bug.cgi?id=1175164
@@ -175,7 +163,6 @@ gyp:
     links:
         bug: https://codereview.chromium.org/1454433002
 iotop:
-  status: released
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282186
     homepage: http://guichaz.free.fr/iotop/
@@ -183,7 +170,6 @@ iotop:
   note: |
     Patch to spec file accepted by maintainer, in QA
 isomd5sum:
-  status: released
   links:
     bug: https://github.com/rhinstaller/isomd5sum/pull/1
 jabber-roster:
@@ -199,7 +185,6 @@ konversation:
         [media script](https://quickgit.kde.org/?p=konversation.git&a=commit&h=285fc5f496363937b3676f33e7b468b8d85cce5e)
         is ported to Python 3 while the rest of the package is not.
 libldb:
-  status: released
   notes: |
     Ported since ldb 1.1.23.
 libfreenect:
@@ -209,15 +194,9 @@ libfreenect:
   links:
     bug: https://github.com/OpenKinect/libfreenect/issues/458
 libplist:
-  status: released
   links:
     repo: http://cgit.libimobiledevice.org/libplist.git/tree/cython
-libtalloc:
-  status: released
-libtdb:
-  status: released
 libtevent:
-  status: released
   note: Ported in tevent 0.9.25
 libxslt:
   links:
@@ -249,17 +228,14 @@ mypaint:
   links:
     bug: https://github.com/mypaint/mypaint/issues/392
 odfpy:
-  status: released
   links:
     repo: https://github.com/eea/odfpy
   note: odfpy is said to support Python 3 as of version 1.3. Fedora's current package is older.
 opencv:
-  status: released
   note: Available since 3.0 release
 openerp-client: *openerp
 openerp7: *openerp
 powerline:
-  status: released
   links:
     repo: https://github.com/powerline/powerline
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282487
@@ -267,31 +243,24 @@ psi4:
   note: |
     A major porting effort by Robert T. McGibbon was [merged](https://github.com/psi4/psi4public/pull/160).
 pssh:
-  status: released
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282544
     repo: https://code.google.com/p/parallel-ssh/source/browse/setup.py
-py-radix:
-  status: released
 pyexiv2:
   status: dropped
   links:
     homepage: http://tilloy.net/dev/pyexiv2/
   note: 'Per homepage: "pyexiv2 is now deprecated in favour of GExiv2."'
 pygsl:
-  status: released
   note: See [release message](http://sourceforge.net/p/pygsl/mailman/message/34494662/)
 pyhunspell:
-  status: released
   links:
     repo: https://github.com/blatinier/pyhunspell
 pymunk:
-  status: released
   links:
     repo: https://github.com/viblo/pymunk
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282551
 pyppd:
-  status: released
   links:
     repo: https://github.com/vitorbaptista/pyppd
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282555
@@ -327,15 +296,12 @@ python-atfork:
     bug: https://github.com/google/python-atfork/pull/1
     repo: https://github.com/google/python-atfork
 python-bitarray:
-  status: released
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282557
     repo: https://github.com/ilanschnell/bitarray
 python-biopython:
-  status: released
   note: Python 3.4 supported since 1.64
 python-bitmath:
-  status: released
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282560
     repo: https://github.com/tbielawa/bitmath
@@ -347,91 +313,65 @@ python-CDDB:
 python-coverage-test-runner: *obnam
 python-cliapp: *obnam
 python-django-admin-honeypot:
-  status: released
   links:
     repo: https://github.com/dmpayton/django-admin-honeypot
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282099
 python-django-annoying:
-  status: released
   links:
     repo: https://github.com/dmpayton/django-admin-honeypot
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282106
 python-django-avatar:
-  status: released
   links:
     repo: https://github.com/grantmcconnaughey/django-avatar/
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282108
 python-django-celery:
-  status: released
   links:
     repo: https://github.com/celery/celery
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282109
 python-django-countries:
-  status: released
   links:
     repo: https://github.com/SmileyChris/django-countries/
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282237
 python-django-extra-form-fields:
-  status: released
   links:
     bug: https://github.com/ASKBOT/django-extra-form-fields/pull/1
-python-django-registration:
-  status: released
 python-flask-debugtoolbar:
-  status: released
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282082
 python-flask-mako:
-  status: released
   links:
       homepage: https://pypi.python.org/pypi/Flask-Mako/
       repo: https://github.com/benselme/flask-mako
   note: "reported with <3 by decause"
 python-formencode:
-  status: released
   note: |
     Upstream has support from 1.3.0.  Some incompatibilities with earlier versions exist.
 python-gencpp:
-    status: released
     repo: https://github.com/ros/gencpp
     note: "[changelog](https://github.com/ros/gencpp/blob/indigo-devel/CHANGELOG.rst#0415-2014-01-07)"
 python-genlisp:
-    status: released
     repo: https://github.com/ros/genlisp
 python-genmsg:
-  status: released
   repo: https://github.com/ros/genmsg
 python-genpy:
     status: released
     repo: https://github.com/ros/genpy
     note: "[changelog](https://github.com/ros/genpy/blob/indigo-devel/CHANGELOG.rst#0415-2014-01-07)"
 python-glue:
- status: released
  repo: https://github.com/jorgebastida/glue
-python-gnupg:
-  status: released
-python-irclib:
-  status: released
-python-kajiki:
-  status: released
 python-keystoneclient:
-  status: released
   links:
     repo: https://github.com/openstack/python-keystoneclient
   note: PY3 compatible since 0.7.0 (see commit aa6c99e)
 python-larch: *obnam
 python-Levenshtein:
-  status: released
   links:
     homepage: https://pypi.python.org/pypi/python-Levenshtein/
   note: Upstream already supports Python 3 by default.
-python-martian:
-  status: released
 python-mechanize:
   links:
     bug: https://github.com/jjlee/mechanize/issues/96
 python-mwclient:
-  status: released
   links:
     repo: https://github.com/mwclient/mwclient
   note: |
@@ -439,7 +379,6 @@ python-mwclient:
     checking this.
     It is included in mwclient-0.8.
 python-oauth2:
-  status: released
   link:
     repo: https://github.com/joestump/python-oauth2
   note:
@@ -449,36 +388,29 @@ python-paste-script:
   note: |
     Python3 support was added in 2.0.0 with numerous python3-related bugfixes through 2.0.2
 python-pdfrw:
-  status: released
   links:
     repo: https://github.com/pmaupin/pdfrw
   note: |
     Upstream states they support 3.3 and 3.4
 python-peewee:
-  status: released
   links:
     repo: https://github.com/coleifer/peewee
   note:
     Since the version 2.1.0, upstream supports Python 3. Also, the code base is
     actively [tested against Python 3.2](https://travis-ci.org/coleifer/peewee) and later.
 python-pmw:
-  status: released
   links:
     homepage: https://pypi.python.org/pypi/Pmw/2.0.1
   note: |
     Python-PMW 2.0.0+ is Python3-only, and 1.3.x is Python2 only.
     The easiest way for Fedora would probably be a new `python3-pmw` source
     package.
-python-progressbar:
-  status: released
 python-pylibmc:
-  status: released
   note: |
     Upstream does support python3; Fedora package needs to be updated
   links:
     repo: https://github.com/lericson/pylibmc
 python-pyprintr:
-  status: released
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282069
     repo: https://github.com/fitoria/pyprintr
@@ -486,7 +418,6 @@ python-pyprintr:
     Upstream is not maintained and every URL is broken; sourcecode could be
     easily ported to Python 3 using 2to3. Ported via [github fork](https://github.com/fitoria/pyprintr)
 python-progressbar:
-  status: released
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282094
 python-repoze-who-plugins-sa:
@@ -496,15 +427,11 @@ python-repoze-who-plugins-sa:
     Python3 support (as well as resistance to timing attacks!) may be
     unreleased but committed to upstream source repository
 python-restsh:
-  status: released
   links:
     repo: https://github.com/jespino/restsh
   note:
     Upstream claims to have support for Python 3.2. Fedora package needs to be updated.
-python-retask:
-  status: released
 python-routes:
-  status: released
   note: |
     Upstream python3 support as of 2.2
 python-rows:
@@ -514,37 +441,29 @@ python-sexy:
     status: idle
     note: |
         Upstream has not maintained this project in almost 10 years (Sept 2006). They are also the authors of libsexy which has not been maintained in 7 years. Refer to the [python-sexy](http://osiris.chipx86.com/svn/osiris-misc/trunk/sexy-python/ChangeLog) and [libsexy](http://osiris.chipx86.com/svn/osiris-misc/trunk/libsexy/ChangeLog) changelogs.
-python-shove:
-  status: released
 python-SimpleCV:
   note: Also blocked by need to port to opencv3 (since opencv2 doesn't support Python 3)
   links:
     bug: https://github.com/sightmachine/SimpleCV/pull/677
 python-sqlobject:
-  status: released
   note: |
     Upstream python3 support is present in 3.0.0a1dev (official snapshot uploaded to pypi).
 python-fedmsg-meta-fedora-infrastructure:
   status: released
 python-statsd:
-  status: released
   links:
     repo: https://github.com/jsocol/pystatsd
   note: |
     Upstream has already fixed the code to support Python 3. The unit tests are
     also [running against 3.X](https://travis-ci.org/jsocol/pystatsd).
 python-tgscheduler:
-  status: released
   links:
     homepage: https://pypi.python.org/pypi/TGScheduler
 python-tracing: *obnam
 python-ttystatus: *obnam
 python-tw2-forms:
-  status: released
   note: |
     Upstream support from 2.2.0 on
-python-xlwt:
-  status: released
 python-xlib:
   note: |
     A Python 3 fork is available at [LiuLang's Github](https://github.com/LiuLang/python3-xlib).
@@ -557,39 +476,31 @@ python-yolk:
   note: |
     A py3-compatible fork, and pull requests, are available.
 python-yourls:
-  status: released
   links:
     homepage: https://pypi.python.org/pypi/yourls
   note: |
     Upstream is py3-compatible.
-python-yubico:
-  status: released
 python-zaqarclient:
-  status: released
   links:
     repo: https://github.com/openstack/zaqar
   note: |
     Upstream version 0.3.0 is py3-compatible.
 python-zope-datetime:
-  status: released
   links:
     homepage: https://pypi.python.org/pypi/zope.datetime
   note: |
     Upstream is py3-compatible since version 4.0.0.
 python-zope-processlifetime:
-  status: released
   links:
     homepage: https://pypi.python.org/pypi/zope.processlifetime
   note: |
     Upstream is py3-compatible since version 2.1.0.
 python-zope-sequencesort:
-  status: released
   links:
     homepage: https://pypi.python.org/pypi/zope.sequencesort
   note: |
     Upstream is py3-compatible since version 4.0.0.
 python-zope-structuredtext:
-  status: released
   links:
     homepage: https://pypi.python.org/pypi/zope.structuredtext
   note: |
@@ -625,7 +536,6 @@ solfege:
   links:
     homepage: https://www.gnu.org/software/solfege/
 speedtest-cli:
-  status: released
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282189
     homepage: https://github.com/sivel/speedtest-cli
@@ -642,17 +552,14 @@ trytond:
   links:
     bug: https://bugs.tryton.org/issue3211
 TurboGears2:
-  status: released
   note: |
     The latest release supports python3
 tweepy:
-  status: released
   links:
       homepage: https://pypi.python.org/pypi/tweepy/
       repo: https://github.com/tweepy/tweepy
   note: "reported with <3 by decause"
 veusz:
-  status: released
   note: Available since 1.19 release
 ViTables:
   links:
@@ -668,8 +575,6 @@ wxPython:
   links:
     homepage: http://wiki.wxpython.org/ProjectPhoenix
     repo: https://github.com/wxWidgets/Phoenix
-xapian-bindings:
-  status: released
 xpra:
   note: Tied with a GTK3 port as well, so may be delayed
   links:


### PR DESCRIPTION
Removed from packages which are:
a) already ported in Fedora, or
b) already tracked as mispackaged or in-progress by portingdb

It remains for 3 packages which cannot be moved to mispackaged due to unported
dependencies.