### PR TITLE
Added a script for finding 'idle' packages marked as 'released' upstream

### DIFF
--- a/portingdb/cli.py
+++ b/portingdb/cli.py
@@ -321,7 +321,12 @@ def update(ctx):
 @cli.command()
 @click.pass_context
 def upstream_idle(ctx):
-    """List packages marked as released upstream which are currently idle."""
+    """List packages marked as released upstream which are currently idle.
+
+    Exits with error code 1 if such packages are found.
+
+    Use the --verbose flag to get the output pretty-printed for humans.
+    """
     db = ctx.obj['db']
 
     query = db.query(tables.CollectionPackage)
@@ -333,12 +338,18 @@ def upstream_idle(ctx):
     query = query.filter(tables.CollectionPackage.status == 'released')
 
     results = list(query)
-    if results:
-        print("\nFollowing packages are both 'idle' and marked as "
-                "'released' upstream:\n")
-        for r in results:
-            print("\t{}".format(r.name))
-        print()
+    if ctx.obj['verbose'] > 0:
+        if results:
+            print("\nThe following packages are both 'idle' and marked as "
+                    "'released' upstream:\n")
+            for r in results:
+                print("\t{}".format(r.name))
+            print()
+        else:
+            print("\nThere are no packages both 'idle' and marked as "
+                    " 'released' upstream.\n")
     else:
-        print("\nThere are no packages both 'idle' and marked as "
-                " 'released' upstream.\n")
+        for r in results:
+            print("{}".format(r.name))
+    if results:
+        exit(1)

--- a/portingdb/cli.py
+++ b/portingdb/cli.py
@@ -318,7 +318,7 @@ def update(ctx):
     from . import queries
     queries.update_group_closures(db)
 
-@cli.command()
+@cli.command('upstream-idle')
 @click.pass_context
 def upstream_idle(ctx):
     """List packages marked as released upstream which are currently idle.

--- a/portingdb/cli.py
+++ b/portingdb/cli.py
@@ -317,3 +317,28 @@ def update(ctx):
 
     from . import queries
     queries.update_group_closures(db)
+
+@cli.command()
+@click.pass_context
+def upstream_idle(ctx):
+    """List packages marked as released upstream which are currently idle."""
+    db = ctx.obj['db']
+
+    query = db.query(tables.CollectionPackage)
+    query = query.join(tables.Package,
+            tables.Package.name == tables.CollectionPackage.name)
+    query = query.filter(tables.Package.status == 'idle')
+    query = query.filter(
+            tables.CollectionPackage.collection_ident == 'upstream')
+    query = query.filter(tables.CollectionPackage.status == 'released')
+
+    results = list(query)
+    if results:
+        print("\nFollowing packages are both 'idle' and marked as "
+                "'released' upstream:\n")
+        for r in results:
+            print("\t{}".format(r.name))
+        print()
+    else:
+        print("\nThere are no packages both 'idle' and marked as "
+                " 'released' upstream.\n")


### PR DESCRIPTION
If you find a better name for the cli command (this would be the first one with an underscore) I'm open to suggestions.