### PR TITLE
python-tuskarclient has been deprecated upstream

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -709,6 +709,7 @@ python-TurboMail:
       Upstream looks dead, project continues under the PyPI name
       `marrow.mailer`, not packaged for Fedora yet.
 python-tuskarclient:
+    status: dropped
     note: |
       From the Fedora bug:
 


### PR DESCRIPTION
python-tuskarclient is currently in the "green section", it should be dropped.
https://bugzilla.redhat.com/show_bug.cgi?id=1309311