### PR TITLE
Fix status of M2Crypto.

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -211,13 +211,15 @@ notify-python:
   note: |
     Last update from upstream was in 2006.
 m2crypto:
-    status: dropped
     note: |
       Suggested replacement: `python-cryptography` (or Python standard library).
 
       While upstream is making progress porting m2crypto, moving to the
       cryptography module, and the cryptography features in Python's standard
       library, seems to be a better long-term option for dependent projects.
+
+      On the other hand with the package ported, downstream users won't
+      have to port their crypto to new library.
 magicor:
     dead-upstream: true
 marave:


### PR DESCRIPTION
M2Crypto is not completely dead, and yes it is not the only Python bindings for OpenSSL, but it still has surprisingly large user base.