### PR TITLE
python-django-setuptest is py3 available

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -404,6 +404,11 @@ python-django-pyscss:
   status: released
   links:
     homepage: https://pypi.python.org/pypi/django-pyscss/2.0.2
+python-django-setuptest:
+  status: released
+  links:
+    homepage: https://github.com/praekelt/django-setuptest
+    repo: https://pypi.python.org/pypi/django-setuptest/0.2.1
 python-eyed3:
   links:
     bug: https://bitbucket.org/nicfit/eyed3/issues/25/python-3-compatibilty


### PR DESCRIPTION
Upstream Python 3 compatible version is available [see a changelog at https://pypi.python.org/pypi/django-setuptest/0.2.1#id31].