### PR TITLE
Not maintained packages

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -418,6 +418,11 @@ python-dateutil15:
     note: |
         This is an old version of the dateutil library.
         Replacement: `python-dateutil`
+python-django-authenticator:
+    note: |
+      Not maintained since 2011
+    links:
+      homepage: https://pypi.python.org/pypi/django-authenticator/0.1.5
 python-django-bootstrap-toolkit:
     note: |
       Project is retired, replaced by not-yet-packaged `django-bootstrap3`
@@ -438,6 +443,11 @@ python-django-dajaxice:
       Unmaintained since django 1.8. Should be avoided.
     links:
       homepage: https://github.com/jorgebastida/django-dajaxice
+python-django-dpaste:
+    note: |
+      Project is retired, replaced by not-yet-packaged `dpaste`
+    links:
+      homepage: https://pypi.python.org/pypi/django-dpaste/0.2.4
 python-django-kombu:
     status: dropped
     note: |
@@ -459,6 +469,11 @@ python-docs:
     status: dropped
     note: |
         Replacement: `python3-docs`
+python-django-staticfiles:
+    note: |
+      part of Django (since 1.3) as `django.contrib.staticfiles`
+    links:
+      homepage: https://pypi.python.org/pypi/django-staticfiles/1.2.1
 python-elixir:
     status: dropped
     note: |

--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -404,6 +404,11 @@ python-django-pyscss:
   status: released
   links:
     homepage: https://pypi.python.org/pypi/django-pyscss/2.0.2
+python-django-setuptest:
+  status: released
+  links:
+    homepage: https://github.com/praekelt/django-setuptest
+    repo: https://pypi.python.org/pypi/django-setuptest/0.2.1
 python-eyed3:
   links:
     bug: https://bitbucket.org/nicfit/eyed3/issues/25/python-3-compatibilty


### PR DESCRIPTION
Not maintained packages:

- python-django-authenticator
    Repository: https://github.com/ASKBOT/django-authenticator
    Not ready for use in production, not maintained since 2011.

- python-django-dpaste
    Repository: https://github.com/digitaljhelms/django-paste
    This package is no longer in development. Please see the successor dpaste.

- python-django-staticfiles
     The package is now part of Django (since 1.3) as django.contrib.staticfiles.