### PR TITLE
Upstream bugs

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -395,6 +395,11 @@ python-django-haystack:
   links:
     homepage: http://haystacksearch.org/
     repo: https://pypi.python.org/pypi/django-haystack/2.5.0
+python-django-openid-auth:
+  links:
+    homepage: https://launchpad.net/django-openid-auth
+    repo: https://pypi.python.org/pypi/django-openid-auth
+    bug: https://caniusepython3.com/project/django-openid-auth
 python-django-pipeline:
   status: released
   links:
@@ -554,6 +559,10 @@ python-repoze-who-plugins-sa:
   note: |
     Python3 support (as well as resistance to timing attacks!) may be
     unreleased but committed to upstream source repository
+python-restkit:
+  links:
+    homepage: https://github.com/benoitc/restkit
+    bug: https://github.com/benoitc/restkit/issues/47
 python-restsh:
   links:
     repo: https://github.com/jespino/restsh


### PR DESCRIPTION
Upstream bugs related to

- python-django-openid-auth (there is not considered that python3-openid is available for Python 3)

- python-restkit