### PR TITLE
Update django upstream status data

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -384,6 +384,10 @@ python-django-countries:
   links:
     repo: https://github.com/SmileyChris/django-countries/
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282237
+python-django-devserver:
+  links:
+    home: https://github.com/dcramer/django-devserver
+    repo: https://pypi.python.org/pypi/django-devserver
 python-django-extra-form-fields:
   links:
     bug: https://github.com/ASKBOT/django-extra-form-fields/pull/1
@@ -395,10 +399,24 @@ python-django-haystack:
   links:
     homepage: http://haystacksearch.org/
     repo: https://pypi.python.org/pypi/django-haystack/2.5.0
+python-django-keyedcache:
+  links:
+    home: http://bitbucket.org/bkroeze/django-keyedcache/
+    repo: https://pypi.python.org/pypi/django-keyedcache
+  note: |
+    Last upstream commit 2015
+    A Python 3 fork is available at [Kunal Deo's Github](https://github.com/kunaldeo/django-keyedcache3) and [PyPI] (https://pypi.python.org/pypi/django-keyedcache3).
 python-django-openid-auth:
   links:
     homepage: https://pypi.python.org/pypi/django-openid-auth
     repo: https://launchpad.net/django-openid-auth
+python-django-pagination:
+  links:
+    home: https://github.com/ericflo/django-pagination
+    repo: https://pypi.python.org/pypi/django-pagination
+  note: |
+    Last upstream commit 2014
+    A Python 3 fork is available at [Thomas Orozco's Github] (https://github.com/krallin/django-pagination).
 python-django-pipeline:
   status: released
   links:
@@ -408,11 +426,32 @@ python-django-pyscss:
   status: released
   links:
     homepage: https://pypi.python.org/pypi/django-pyscss/2.0.2
+python-django-roa:
+  linmks:
+    home: https://github.com/charles-vdulac/django-roa
+    repo: https://pypi.python.org/pypi/django-roa
+  note: |
+    Last upstream commit 2015
 python-django-setuptest:
   status: released
   links:
     homepage: https://github.com/praekelt/django-setuptest
     repo: https://pypi.python.org/pypi/django-setuptest/0.2.1
+python-django-stopforumspam:
+  links:
+    home: https://overtag.dk/
+    repo: https://pypi.python.org/pypi/stopforumspam
+python-django-tracking:
+  links:
+    home: https://github.com/bashu/django-tracking
+    repo: https://pypi.python.org/pypi/django-tracking
+  note: |
+    Last upstream commit 2015
+python-django-threadedcomments:
+  links:
+    home: https://github.com/HonzaKral/django-threadedcomments
+    repo: https://pypi.python.org/pypi/django-threadedcomments
+    bug: https://github.com/HonzaKral/django-threadedcomments/issues/79
 python-eyed3:
   links:
     bug: https://bitbucket.org/nicfit/eyed3/issues/25/python-3-compatibilty


### PR DESCRIPTION
Upstream status update (home, repo and bug links, last commits) of several python-django-* packages that have not been Python 3 compatible yet, and forks that are Python 3 compatible.