### PR TITLE
Update status on fabric

### DIFF
--- a/data/fedora.json
+++ b/data/fedora.json
@@ -5662,9 +5662,9 @@
     ],
     "links": {
       "bug": [
-        "https://bugzilla.redhat.com/show_bug.cgi?id=1324108",
-        "CLOSED NOTABUG",
-        "2016-05-10 20:19:20"
+        "https://bugzilla.redhat.com/show_bug.cgi?id=1370016",
+        "NEW",
+        "2016-08-25 00:43:13"
       ]
     },
     "rpms": {
@@ -5673,7 +5673,7 @@
         "python(abi) = 2.7": 2
       }
     },
-    "status": "idle"
+    "status": "in-progress"
   },
   "fail2ban": {
     "deps": [


### PR DESCRIPTION
I submitted https://bugzilla.redhat.com/show_bug.cgi?id=1370016 to request that Fedora use @mathiasertl 's [Python 3 compatible fork of fabric](https://github.com/mathiasertl/fabric).