### PR TITLE
livecd-tools has been ported to DNF and Python 3

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -247,6 +247,14 @@ libxslt:
 lilypond:
   status: idle
   note: Python 3 is not currently supported upstream.
+livecd-tools:
+  status: in-progress
+  links:
+    bug: https://github.com/rhinstaller/livecd-tools/pull/37
+    repo: https://github.com/rhinstaller/livecd-tools
+  note: |
+      Kevin Kofler ported livecd-tools to DNF, and Neal Gompa ported livecd-tools to Python 3.
+      The changes are pending upstream review via GitHub pull request.
 lnst:
   links:
     bug: https://github.com/jpirko/lnst/issues/105


### PR DESCRIPTION
The pull request is under review.