### PR TITLE
Remove the in-progress  status in favor of more visible Bugzilla last-change date

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -239,7 +239,6 @@ lilypond:
   status: idle
   note: Python 3 is not currently supported upstream.
 livecd-tools:
-  status: in-progress
   links:
     bug: https://github.com/rhinstaller/livecd-tools/pull/37
     repo: https://github.com/rhinstaller/livecd-tools

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -288,10 +288,8 @@ class Py3QueryCommand(dnf.cli.Command):
                         r.setdefault('tracking_bugs', []) \
                                 .append(BUGZILLA_BUG_URL.format(tb))
 
-                if any(tb in bug.blocks for tb in MISPACKAGED_TRACKER_BUG_IDS):
-                    if r.get('status') == 'idle' and bug.status != 'NEW':
-                        r['status'] = 'in-progress'
-                    elif r.get('status') == 'idle' and bug.status == 'NEW':
+                if (any(tb in bug.blocks for tb in MISPACKAGED_TRACKER_BUG_IDS)
+                    and r.get('status') == 'idle'):
                         r['status'] = "mispackaged"
                         r['note'] = ('There is a problem in Fedora packaging, ' +
                                     'not necessarily with the software itself. ' +

--- a/portingdb/htmlreport.py
+++ b/portingdb/htmlreport.py
@@ -723,7 +723,7 @@ def mispackaged():
         'mispackaged.html',
         breadcrumbs=(
             (url_for('hello'), 'Python 3 Porting Database'),
-            (url_for('mispackaged'), 'Mispackaged'),
+            (url_for('mispackaged', requested=1), 'Mispackaged'),
         ),
         requested=bool(requested),
         mispackaged=mispackaged,

--- a/portingdb/htmlreport.py
+++ b/portingdb/htmlreport.py
@@ -66,6 +66,12 @@ def hello():
     mispackaged = query.filter(tables.Package.status == 'mispackaged')
     mispackaged = mispackaged.options(subqueryload('collection_packages'))
     mispackaged = mispackaged.options(subqueryload('collection_packages.tracking_bugs'))
+    mispackaged = mispackaged.join(tables.CollectionPackage)
+    mispackaged = mispackaged.outerjoin(
+        tables.Link,
+        and_(tables.Link.type == 'bug',
+             tables.Link.collection_package_id == tables.CollectionPackage.id))
+    mispackaged = mispackaged.order_by(func.ifnull(tables.Link.last_update, '9999'))
     mispackaged = queries.order_by_name(db, mispackaged)
 
     blocked = query.filter(tables.Package.status == 'blocked')

--- a/portingdb/htmlreport.py
+++ b/portingdb/htmlreport.py
@@ -111,6 +111,13 @@ def hello():
     groups = get_groups(db, query.filter(~tables.Group.hidden))
     hidden_groups = get_groups(db, query.filter(tables.Group.hidden))
 
+    # Statuses with no. of packages
+    statuses = OrderedDict(
+        db.query(tables.Status, func.count(tables.Package.name))
+        .outerjoin(tables.Status.packages)
+        .group_by(tables.Status.ident)
+        .order_by(tables.Status.order))
+
     return render_template(
         'index.html',
         breadcrumbs=(
@@ -118,8 +125,7 @@ def hello():
         ),
         collections=collections,
         coll_info=coll_info,
-        statuses=list(db.query(tables.Status)
-                .filter(tables.Status.ident != 'unknown').order_by(tables.Status.order)),
+        statuses=statuses,
         priorities=list(db.query(tables.Priority).order_by(tables.Priority.order)),
         total_pkg_count=total_pkg_count,
         status_summary=get_status_summary(db),

--- a/portingdb/templates/howto.html
+++ b/portingdb/templates/howto.html
@@ -24,9 +24,9 @@
 
         <h2 id="package-it">Package it</h2>
         <p>
-            There are currently <a href="{{ url_for('mispackaged') }}">{{ len(mispackaged) }} packages</a> that are Python 3–ready upstream (that we know of), but not quite yet Python 3–ready in Fedora. These are labeled as "mispackaged" in PortingDB.
+            There are currently <a href="{{ url_for('hello', _anchor='mispackaged') }}">{{ len(mispackaged) }} packages</a> that are Python 3–ready upstream (that we know of), but not quite yet Python 3–ready in Fedora. These are labeled as "mispackaged" in PortingDB.
         </p><p>
-            You can view the <a href="{{ url_for('mispackaged') }}">mispackaged packages</a> ordered by their last activity, so you can pick one off the top and be relatively sure nobody is currently working on it.
+            You can view the <a href="{{ url_for('hello', _anchor='mispackaged') }}">mispackaged packages</a> ordered by their last activity, so you can pick one off the top and be relatively sure nobody is currently working on it.
             Alternatively, you can pick one of <a href="{{ url_for('mispackaged', requested=1) }}">these packages</a>, where the packager explicitly asked for someone to provide a patch since they don't have the time for it.
         </p><p>
             Now open the package in PortingDB (e.g. {{ pkglink(random_mispackaged) }}): The {{ badge(mispackaged_status) }} next to <i>Fedora</i> in the sidebar indicates that indeed we are dealing with a mispackaged package.

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -80,22 +80,40 @@
                     {{ len(mispackaged_packages) }} packages were found to have some kind of packaging problem.
                 </div>
                 <div style="padding-bottom: 7pt">
-                    To find the best package to port, see <a href="{{
-                    url_for('mispackaged') }}">packages ordered by last
-                    activity</a>.<br/>
+                    You can also see <a href="{{
+                    url_for('mispackaged', requested=1) }}">only packages for which the
+                    maintainer requested a patch</a>.<br/>
                     For more information read: <a href="{{ url_for('howto')
                     }}">So you want to contribute?</a>
                 </div>
-                <ul class="simple-pkg-list">
-                {% for pkg in mispackaged_packages %}
-                    <li>
+                <table class="table table-striped table-condensed table-hovered">
+                    <tr>
+                        <th>Package</th>
+                        <th>Last activity</th>
+                    </tr>
+
+                    {% for pkg in mispackaged_packages %}
+                    <tr>
+                        <td>
                             {{ pkglink(pkg) }}
-                            {% if "https://bugzilla.redhat.com/show_bug.cgi?id=1333765" in pkg.list_tracking_bugs %}
-                               (patch requested by maintainer)
+                            {% if "https://bugzilla.redhat.com/show_bug.cgi?id=1333765"
+                                  in pkg.list_tracking_bugs %}
+                            (patch requested by maintainer)
                             {% endif %}
-                    </li>
-                {% endfor %}
-                </ul>
+                        </td>
+                        <td>
+                            {% if pkg.last_link_update %}
+                                <time title="{{ pkg.last_link_update }}">
+                                    {{ pkg.last_link_update | format_time_ago }}
+                                </time>
+                            {% else %}
+                                no Bugzilla report yet
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </table>
+
             {% endif %}
             <h2 id="idle">Idle packages</h2>
             <div>

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -64,14 +64,16 @@
                     </div>
                 {% endfor %}
             {% endif %}
-            <h2 id="in-progress">Porting in Progress</h2>
-            <div>
-                We know about {{ len(active_packages) }} packages that
-                someone is actively porting, or which are waiting for review.
-            </div>
-            <table class="table table-striped table-condensed table-hovered">
-               {{ pkglist_table_content(active_packages, collections) }}
-            </table>
+            {% if active_packages %}
+                <h2 id="in-progress">Porting in Progress</h2>
+                <div>
+                    We know about {{ len(active_packages) }} packages that
+                    someone is actively porting, or which are waiting for review.
+                </div>
+                <table class="table table-striped table-condensed table-hovered">
+                {{ pkglist_table_content(active_packages, collections) }}
+                </table>
+            {% endif %}
             {% if mispackaged_packages %}
                 <h2 id="mispackaged">Mispackaged packages</h2>
                 <div>
@@ -178,12 +180,14 @@
             {% endif %}
             <h2>Status Legend</h2>
             <ul class="list-group">
-                {% for status in statuses %}
-                    <li class="list-group-item">
-                        {{ minibadge(status) }}
-                        <a href="#{{ status.ident }}">{{ status.name }}</a>
-                        <div><small>{{ status.description }}</small></div>
-                    </li>
+                {% for status, num_packages in statuses.items() %}
+                    {% if num_packages %}
+                        <li class="list-group-item">
+                            {{ minibadge(status) }}
+                            <a href="#{{ status.ident }}">{{ status.name }}</a>
+                            <div><small>{{ status.description }}</small></div>
+                        </li>
+                    {% endif %}
                 {% endfor %}
             </ul>
             <div>

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -29,7 +29,7 @@
                 {{ config['main-instructions']
                         .replace('$RANDOMPKG', pkglink(random_mispackaged))
                         .replace('$HOWTO_LINK', url_for('howto'))
-                        .replace('$MISPACKAGED_LINK', url_for('mispackaged'))
+                        .replace('$MISPACKAGED_LINK', '#mispackaged')
                     |safe }}
             {% endif %}
             {% if groups %}

--- a/portingdb/templates/mispackaged.html
+++ b/portingdb/templates/mispackaged.html
@@ -8,17 +8,20 @@
 
 <div class="container">
     <div class="col-md-12">
-        <h1>Mispackaged packages</h1>
-        <p>
-            Ordered by last activity.
-        </p>
-        <p style="padding-bottom: 5pt">
-            {% if not requested %}
-                You can view either <i>all the packages</i> or <a href="{{ url_for('mispackaged', requested=1) }}">the packages where the maintainer requested a patch</a>.
-            {% else %}
-                You can view either <a href="{{ url_for('mispackaged') }}">all the packages</a> or <i>the packages where the maintainer requested a patch</i>.
-            {% endif %}
-        </p>
+        <h1>Mispackaged</h1>
+        {% if requested %}
+            <p>
+                Mispackaged packages for which the maintainer requested a patch.
+                Ordered by last activity.
+            </p>
+        {% else %}
+            <p>
+                All mispackaged packages, ordered by last activity.
+            </p>
+            <p style="padding-bottom: 5pt">
+                You can also view only <a href="{{ url_for('mispackaged', requested=1) }}">the packages for which the maintainer requested a patch</a>.
+            </p>
+        {% endif %}
 
         {% if not mispackaged %}
         <p>


### PR DESCRIPTION
The `in-progress` status isn't really useful, since it mostly tracks when people signed up to do some work – which doesn't necessarily mean they'll actually do the work in finite time.

Stop generating `in-progress`, hide it (along with any other unused statuses) from the main page, and instead show the table from http://portingdb-encukou.rhcloud.com/mispackaged/ right on the main page.