### PR TITLE
python-django-stopforumspam is upstream Python 3 available

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -450,8 +450,9 @@ python-django-setuptest:
     homepage: https://github.com/praekelt/django-setuptest
     repo: https://pypi.python.org/pypi/django-setuptest/0.2.1
 python-django-stopforumspam:
+  status: released
   links:
-    repo: https://overtag.dk/
+    repo: https://github.com/benjaoming/django-stopforumspam
     homepage: https://pypi.python.org/pypi/stopforumspam
 python-django-threadedcomments:
   links:


### PR DESCRIPTION
Bugzilla can be open for python-django-stopforumspam, version 1.7, to provide a Python 3 package for Fedora.