### PR TITLE
trash-cli Python 3 upstream available

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -761,10 +761,10 @@ trac:
   links:
     bug: https://trac.edgewall.org/ticket/10083
 trash-cli:
-  note: |
-    Pending upstream pull request
+  status: released
   links:
-    bug: https://github.com/andreafrancia/trash-cli/pull/62
+    repo: https://github.com/andreafrancia/trash-cli/
+    homepage: https://pypi.python.org/pypi/trash-cli/
 trytond:
   status: released
   links:


### PR DESCRIPTION
Bugzilla can be open for trash-cli to provide a Python 3 package for Fedora.