### PR TITLE
Identify packages with py2 only binaries

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -99,6 +99,12 @@ cwiid:
 dpdk:
     note: |
         Python 3 support committed but not yet released. (March 2016)
+dreampie:
+    status: idle
+    note: |
+        There's a python2 and a python3 subpackage, but they do different
+        things. dreampie-python3 is a plugin to run python3 interpreter
+        from within dreampie.
 drobo-utils:
     dead-upstream: true
 dtrx:
@@ -541,6 +547,11 @@ python-halite:
         "Halite is officially retired."
 python-HTMLgen:
     dead-upstream: true
+python-igor:
+    note: |
+        The package is functional under python3, but the executable output
+        is  slightly nicer under python2. So it is on py2 on purpose
+        according to the maintainer.
 python-ipaddr:
     status: dropped
     note: |
@@ -820,6 +831,9 @@ python-webtest1.3:
       ported to the current version of the library as part of porting to
       python3.
       Replacement: `python-webtest`
+python-whisper:
+    note: |
+        Whisper as library is python3 compatible, but the executables not yet.
 python-zbase32: &pyutil-zbase32-cycle
     nonblocking: true
     note: |

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -130,25 +130,45 @@ def progressbar(seq, text, namegetter=str):
     print(file=sys.stderr)
 
 
+def binaries(packages):
+    """Return the total number of binaries in the packages."""
+    binaries = [
+        filepath for pkg in packages
+        for filepath in pkg.files
+        if filepath.startswith('/usr/bin')]
+    return len(binaries)
+
+
 def set_status(result, pkgs, python_versions):
     # Look at the Python dependencies of given packages, based on the
     # name only (this means different arches are grouped into one)
     name_by_version = collections.defaultdict(set)
+    pkg_by_version = collections.defaultdict(set)
     for p in pkgs:
         for v in python_versions[p]:
             name_by_version[v].add(p.name)
+            pkg_by_version[v].add(p)
+
     if name_by_version[2] & name_by_version[3]:
         # If a package depends on *both* py2 and py3, it's not ported
         result['status'] = 'mispackaged'
-        result['note'] = ('A single package depends on both Python 2 and '+
-            'Python 3.\n' +
-            'It should be split into a python2 and python3 subpackages ' +
+        result['note'] = (
+            'A single package depends on both Python 2 and '
+            'Python 3.\n'
+            'It should be split into a python2 and python3 subpackages '
             'to prevent it from always dragging the py2 dependency in.')
     else:
         # Otherwise, a srpm isn't ported if it has more packages that need py2
         # than those that need py3
         if len(name_by_version[3]) >= len(name_by_version[2]):
-            result['status'] = 'released'
+            if binaries(pkg_by_version[2]) and not binaries(pkg_by_version[3]):
+                # Identify packages with py2 only binaries.
+                result['status'] = 'mispackaged'
+                result['note'] = (
+                    'The Python 3 package is missing binaries available '
+                    'in a Python 2 package.\n')
+            else:
+                result['status'] = 'released'
         else:
             result['status'] = 'idle'
 

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -40,6 +40,7 @@ ADDITIONAL_TRACKER_BUGS = [
     1333765,  # PY3PATCH-REQUESTED
     1312032,  # PY3PATCH-AVAILABLE
     1333770,  # PY3PATCH-PUSH
+    1432186,  # Missing PY3-EXECUTABLES
 ]
 
 # Template URL to which you can add the bug ID and get a working URL

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -135,7 +135,7 @@ def binaries(packages):
     binaries = [
         filepath for pkg in packages
         for filepath in pkg.files
-        if filepath.startswith('/usr/bin')]
+        if filepath.startswith(('/usr/bin', '/usr/sbin'))]
     return len(binaries)
 
 

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -130,13 +130,13 @@ def progressbar(seq, text, namegetter=str):
     print(file=sys.stderr)
 
 
-def binaries(packages):
-    """Return the total number of binaries in the packages."""
-    binaries = [
-        filepath for pkg in packages
-        for filepath in pkg.files
-        if filepath.startswith(('/usr/bin', '/usr/sbin'))]
-    return len(binaries)
+def have_binaries(packages):
+    """Check if there are any binaries in the packages."""
+    for pkg in packages:
+        for filepath in pkg.files:
+            if filepath.startswith(('/usr/bin', '/usr/sbin')):
+                return True
+    return False
 
 
 def set_status(result, pkgs, python_versions):
@@ -161,7 +161,7 @@ def set_status(result, pkgs, python_versions):
         # Otherwise, a srpm isn't ported if it has more packages that need py2
         # than those that need py3
         if len(name_by_version[3]) >= len(name_by_version[2]):
-            if binaries(pkg_by_version[2]) and not binaries(pkg_by_version[3]):
+            if have_binaries(pkg_by_version[2]) and not have_binaries(pkg_by_version[3]):
                 # Identify packages with py2 only binaries.
                 result['status'] = 'mispackaged'
                 result['note'] = (


### PR DESCRIPTION
Automatically find packages where only the python2 subpackage has something in `/usr/bin`.

This is a naive approach, which simply counts the number of files in `/usr/bin` for both py2 and py3 packages and marks as mispackaged those, where only the py2 subpackage contains binaries (issue #132).