### PR TITLE
graphviz repo and homepage links

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -215,6 +215,10 @@ gobject-introspection:
   links:
     homepage: https://wiki.gnome.org/Initiatives/GnomeGoals/Python3Porting
     bug: https://bugzilla.gnome.org/show_bug.cgi?id=679438
+graphviz:
+  links:
+    repo: https://github.com/ellson/graphviz/
+    homepage: http://www.graphviz.org/
 gyp:
     links:
         bug: https://codereview.chromium.org/1454433002


### PR DESCRIPTION
Because of two quite different graphviz packages, proper repo and homepage links are included to avoid a confusion.