### PR TITLE
Collect data for incorrectly named Python 2 packages

### DIFF
--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -174,6 +174,17 @@ def set_status(result, pkgs, python_versions):
         else:
             result['status'] = 'idle'
 
+    set_py2status(result, pkg_by_version)
+
+
+def set_py2status(result, pkg_by_version):
+    """Check if Python 2 subpackages are correctly named."""
+    result['py2status'] = 'released'
+    for pkg in pkg_by_version[2]:
+        if pkg.name.startswith('python-') or pkg.name.endswith('-python'):
+            result['py2status'] = 'mispackaged'
+            break
+
 
 def format_rpm_name(pkg):
     if pkg.epoch:

--- a/portingdb/load.py
+++ b/portingdb/load.py
@@ -60,6 +60,7 @@ def _get_pkg(name, collection, info):
         'collection_ident': collection,
         'name': info.get('aka') or name,
         'status': info.get('status') or 'unknown',
+        'py2status': info.get('py2status') or 'unknown',
         'priority': info.get('priority') or 'unknown',
         'deadline': info.get('deadline', None),
         'note': info.get('note', None),
@@ -300,6 +301,7 @@ def load_from_directories(db, directories):
               key_columns=['group_ident', 'package_name'])
 
     queries.update_status_summaries(db)
+    queries.update_py2status_summaries(db)
     queries.update_group_closures(db)
 
     values = data_from_csv(directories, 'history')

--- a/portingdb/tables.py
+++ b/portingdb/tables.py
@@ -98,6 +98,9 @@ class Package(TableBase):
     status = Column(
         Unicode(), ForeignKey(Status.ident), nullable=False,
         doc=u"Summarized status")
+    py2status = Column(
+        Unicode(), ForeignKey(Status.ident), nullable=True,
+        doc=u"Status of Python 2 subpackage")
 
     loc_python = Column(
         Integer(), nullable=True,
@@ -116,7 +119,9 @@ class Package(TableBase):
         'CollectionPackage',
         collection_class=mapped_collection(lambda cp: cp.collection.ident))
     status_obj = relationship(
-        'Status', backref=backref('packages'))
+        'Status', backref=backref('packages'), foreign_keys=[status])
+    py2status_obj = relationship(
+        'Status', backref=backref('py2packages'), foreign_keys=[py2status])
 
     def __repr__(self):
         return '<{} {}>'.format(type(self).__qualname__, self.name)
@@ -210,6 +215,8 @@ class CollectionPackage(TableBase):
         doc=u"The package name, as it appears in this collection")
     status = Column(
         Unicode(), ForeignKey(Status.ident), nullable=False)
+    py2status = Column(
+        Unicode(), ForeignKey(Status.ident), nullable=True)
     priority = Column(
         Unicode(), ForeignKey(Priority.ident), nullable=False)
     deadline = Column(
@@ -227,7 +234,9 @@ class CollectionPackage(TableBase):
     collection = relationship(
         'Collection', backref=backref('collection_packages'))
     status_obj = relationship(
-        'Status', backref=backref('collection_packages'))
+        'Status', backref=backref('collection_packages'), foreign_keys=[status])
+    py2status_obj = relationship(
+        'Status', backref=backref('py2collection_packages'), foreign_keys=[py2status])
     priority_obj = relationship(
         'Priority', backref=backref('collection_packages'))
 


### PR DESCRIPTION
This PR is **step 1** for #268 .

- [x] Create a separate status to track Python 2 renaming progress.
- [x] Store it in database as `py2status` column for `Package` and `CollectionPackage`
- [x] Collect it via dnf plugin and save to`fedora.json` to keep track of changes

Note: the database scheme is changed, so the db needs to be reloaded.
Result: There are 897 packages which are to be renamed to `python2-` .