### PR TITLE
Add links to naming policy sidebar sections for easier navigation

### DIFF
--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -233,9 +233,11 @@
             <ul class="list-group">
                 {% for status, count in naming_progress %}
                 <li class="list-group-item">
+                    {% if status.ident != 'name-correct' %}<a href="{{url_for('namingpolicy') }}#{{ status.ident }}">{% endif %}
                     {{ count }}
                     {{ minibadge(status) }}
                     <strong>{{ status.name }}</strong>
+                    {% if status.ident != 'name-correct' %}</a>{% endif %}
                     <div><small>{{ status.short_description }}</small></div>
                 </li>
                 {% endfor %}


### PR DESCRIPTION
We have discovered, that people tend to navigate to naming policy from the subsections of the sidebar on the index page. So providing links there.

![image](https://cloud.githubusercontent.com/assets/5603118/26111365/32da4224-3a55-11e7-826d-209e55adce6d.png)
