### PR TITLE
Packages Python 3 upstream available

### DIFF
--- a/data/upstream.yaml
+++ b/data/upstream.yaml
@@ -194,6 +194,8 @@ frescobaldi:
         homepage: http://www.frescobaldi.org/
         repo: https://github.com/wbsoft/frescobaldi
 genbackupdata: *obnam
+gfal2-python:
+  status: released
 gitstats:
   note: |
       Pending upstream pull request
@@ -206,10 +208,14 @@ glances:
 glacier-cli:
     links:
         bug: https://github.com/basak/glacier-cli/pull/54
+gnatcoll:
+  status: released
 gnome-tweak-tool:
     note: Python 3 is not currently supported upstream.
     links:
         bug: https://bugzilla.gnome.org/show_bug.cgi?id=740219
+gnucash:
+  status: released
 gobject-introspection:
   status: released
   links:
@@ -222,6 +228,8 @@ graphviz:
 gyp:
     links:
         bug: https://codereview.chromium.org/1454433002
+hivex:
+  status: released
 iotop:
   links:
     bug: https://bugzilla.redhat.com/show_bug.cgi?id=1282186


### PR DESCRIPTION
- [ ] gfal2-python [[https://its.cern.ch/jira/browse/DMC-875](https://its.cern.ch/jira/browse/DMC-875)]
- [ ] gnatcoll [[http://libre.adacore.com/developers/development-log-single/NF-15-L619-031-gnatcoll](http://libre.adacore.com/developers/development-log-single/NF-15-L619-031-gnatcoll)]
- [ ] gnucash [[Documentation - chapter 2](https://media.readthedocs.org/pdf/piecash/latest/piecash.pdf)]
- [ ] hivex [[Python 3 package already available in Ubuntu](https://www.ubuntuupdates.org/package/core/zesty/universe/base/python3-hivex)]