### PR TITLE
DNF plugin: Mark packages that just have py2 binaries as nonblocking

### DIFF
--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -161,6 +161,7 @@ def set_status(result, pkgs, python_versions):
             if have_binaries(pkg_by_version[2]) and not have_binaries(pkg_by_version[3]):
                 # Identify packages with py2 only binaries.
                 result['status'] = 'mispackaged'
+                result['nonblocking'] = True
                 result['note'] = (
                     'The Python 3 package is missing binaries available '
                     'in a Python 2 package.\n')


### PR DESCRIPTION
Packages such as python-pbr have Python 2 binaries, but are otherwise
ported. Portingdb currently shows them as mispackaged, so anything
that depends on them shows up as Blocked, even though they can be
ported.

Mark these packages as nonblocking.