### PR TITLE
Weak dependencies for naming policy

### DIFF
--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -257,6 +257,9 @@ class Py3QueryCommand(dnf.cli.Command):
         # unversioned_requirers: {srpm_name: set of srpm_names}
         unversioned_requirers = collections.defaultdict(set)
         for pkg in progressbar(self.all_unqualified_requires(), 'Getting unversioned requirers'):
+            # Ignore Python 3 only packages when checking requires.
+            if python_versions.get(pkg) == {3}:
+                continue
             for require in (pkg.requires + pkg.requires_pre + pkg.recommends +
                             pkg.suggests + pkg.supplements + pkg.enhances):
                 require = str(require).split()[0]

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -256,7 +256,8 @@ class Py3QueryCommand(dnf.cli.Command):
 
         # unversioned_requirers: {srpm_name: set of srpm_names}
         unversioned_requirers = collections.defaultdict(set)
-        for pkg in progressbar(self.all_unqualified_requires(), 'Getting unversioned requirers'):
+        for pkg in progressbar(self.all_unqualified_requires(),
+                               'Processing packages with unversioned dependencies'):
             # Ignore Python 3 only packages when checking requires.
             if python_versions.get(pkg) == {3}:
                 continue
@@ -373,18 +374,22 @@ class Py3QueryCommand(dnf.cli.Command):
         runtime, buildtime or weak dependencies.
         """
         unqualified_wildcards = ['python-*', '[!/]*-python-*', '[!/]*-python']
-        requireres = set()
-
+        bar = iter(progressbar(['Runtime', 'Weak ', 'Buildtime'],
+                               'Querying packages with unversioned dependencies'))
+        requires = set()
         # Check runtime dependencies.
-        requireres.update(self.pkg_query.filter(requires__glob=unqualified_wildcards).run())
+        next(bar)
+        requires.update(self.pkg_query.filter(requires__glob=unqualified_wildcards).run())
 
         # Check weak dependencies.
+        next(bar)
         for wildcard in unqualified_wildcards:
-            requireres.update(self.pkg_query.filter(recommends__glob=wildcard).run())
-            requireres.update(self.pkg_query.filter(suggests__glob=wildcard).run())
-            requireres.update(self.pkg_query.filter(supplements__glob=wildcard).run())
-            requireres.update(self.pkg_query.filter(enhances__glob=wildcard).run())
+            requires.update(self.pkg_query.filter(recommends__glob=wildcard).run())
+            requires.update(self.pkg_query.filter(suggests__glob=wildcard).run())
+            requires.update(self.pkg_query.filter(supplements__glob=wildcard).run())
+            requires.update(self.pkg_query.filter(enhances__glob=wildcard).run())
 
         # Check buildtime dependencies.
-        requireres.update(self.src_query.filter(requires__glob=unqualified_wildcards).run())
-        return requireres
+        next(bar)
+        requires.update(self.src_query.filter(requires__glob=unqualified_wildcards).run())
+        return requires

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -264,7 +264,7 @@ class Py3QueryCommand(dnf.cli.Command):
                             pkg.suggests + pkg.supplements + pkg.enhances):
                 require = str(require).split()[0]
                 requirement = all_provides.get(require)
-                if is_unversioned(require) and requirement:
+                if is_unversioned(require) and requirement and not require.endswith('-doc'):
                     requirement_srpm_name = hawkey.split_nevra(requirement.sourcerpm).name
                     requirer_srpm_name = hawkey.split_nevra(
                         pkg.sourcerpm).name if pkg.sourcerpm else pkg.name


### PR DESCRIPTION
- Check weak dependencies for naming policy
- Ignore Python 3 only packages when checking dependencies
- Ignore unqualified dependency on documentation packages (python-foo-doc)

Fixes #307