### PR TITLE
py3query.py update

### DIFF
--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -1,9 +1,9 @@
 """
-DNF plugin for getting the Python 3 porting status
+DNF plugin for getting the Python 3 porting status.
 
 Put this in your DNF plugin directory, then run:
 
-    $ dnf --enable=rawhide --enable=rawhide-source py3query -o fedora.json
+    $ dnf --enablerepo=rawhide --enablerepo=rawhide-source py3query -o fedora.json
 
 This will give you a file "fedora.json" with information for portingdb.
 """

--- a/docs/update_portingdb.rst
+++ b/docs/update_portingdb.rst
@@ -4,30 +4,32 @@ Update portingdb data
 Setup (to be run just once and if needed)
 *****************************************
 
-To use the `portingdb` update scripts, you will need to install and configure the following:
+To use the portingdb update scripts, you will need to install and configure the following:
 
-#. Put `py3query.py` in DNF plugin directory::
+#. Put ``py3query.py`` in DNF plugin directory::
     
-    sudo cp dnf-plugins/py3query.py /usr/lib/python3.5/site-packages/dnf-plugins/
+    sudo cp dnf-plugins/py3query.py /usr/lib/pythonX.X/site-packages/dnf-plugins/
+
+   Note: replace ``pythonX.X`` with the Python version of your system.
 
 #. Install the rawhide repo definitions::
     
     sudo dnf install fedora-repos-rawhide
 
-#. Install `python3-blessings` which is an additional dependency for `scripts/get-history.py`::
+#. Install ``python3-blessings`` which is an additional dependency for ``scripts/get-history.py``::
 
     sudo dnf install python3-blessings
 
 Update and load data
 ********************
 
-Follow the steps below to update `pordingdb` data:
+Follow the steps below to update pordingdb data:
 
-#. Get the Python 3 porting status using `py3query` dnf plugin. Use `-o` option to write the output directly to `fedora.json`::
+#. Get the Python 3 porting status using ``py3query`` dnf plugin. Use ``-o`` option to write the output directly to ``fedora.json``::
 
     dnf-3 --disablerepo='*' --enablerepo=rawhide --enablerepo=rawhide-source py3query --refresh -o data/fedora.json
 
-#. Get historical status data and update `history.csv`::
+#. Get historical status data and update ``history.csv``::
 
     python3 -u scripts/get-history.py --update data/history.csv | tee history.csv
     mv history.csv data/history.csv
@@ -100,7 +102,7 @@ missing -> idle
 relesed -> mispackaged
     There is an issue with Python 3 subpackage:
 
-* Open the package in `portingdb` and check requirements for `python3-` subpackage:
+* Open the package in portingdb and check requirements for ``python3-`` subpackage:
 
   * If the subpackage is dragging py2 dependency in, check the latest change and find what caused it
   * File a bug

--- a/docs/update_portingdb.rst
+++ b/docs/update_portingdb.rst
@@ -6,6 +6,8 @@ Setup (to be run just once and if needed)
 
 To use the portingdb update scripts, you will need to install and configure the following:
 
+#. Ensure that you run Fedora 26 or higher. The DNF plugin requires DNF-2 released in F26, due to incompatible CLI changes in API methods.
+
 #. Put ``py3query.py`` in DNF plugin directory::
     
     sudo cp dnf-plugins/py3query.py /usr/lib/pythonX.X/site-packages/dnf-plugins/


### PR DESCRIPTION
After update to F26 the `py3query.py` plugin started to fail with:
`dnf py3query: error: unrecognized arguments: -o data/fedora.json`

- [x] Update the plugin structure according to the latest [dnf version recommendations](http://dnf.readthedocs.io/en/latest/use_cases.html#plugins-cli-api)
- [x] Remove `if self.opts.help_cmd` conditionals, which I believe were fixed upstream in [commit](https://github.com/rpm-software-management/dnf/commit/24345fe8dd8223fb83cc65d4607c5222d4d55ab2)
- [x] Update docs to not be bound to python3.5