### PR TITLE
Remove Contact

### DIFF
--- a/portingdb/load.py
+++ b/portingdb/load.py
@@ -297,8 +297,6 @@ def load_from_directories(db, directories):
         bulk_load(db, values, tables.RPMPyDependency.__table__,
                   key_columns=['rpm_id', 'py_dependency_name'])
 
-        # TODO: Contacts
-
     group_values = data_from_file(directories, 'groups')
     values = [{
         'ident': k,

--- a/portingdb/tables.py
+++ b/portingdb/tables.py
@@ -369,28 +369,6 @@ class Link(TableBase):
                                            self.url)
 
 
-class Contact(TableBase):
-    u"""Person associated with a package."""
-    __tablename__ = 'contacts'
-    __table_args__ = (UniqueConstraint('collection_package_id', 'name'), )
-    id = IDColumn()
-    collection_package_id = Column(
-        ForeignKey(CollectionPackage.id), nullable=False)
-    name = Column(
-        Unicode(), nullable=False)
-    role = Column(
-        Enum('owner', 'manager', 'porter'),
-        primary_key=True, nullable=False)
-
-    collection_package = relationship(
-        'CollectionPackage', backref=backref('contacts'))
-
-    def __repr__(self):
-        return '<{} {} for {}: {}>'.format(type(self).__qualname__, self.role,
-                                           self.collection_package.name,
-                                           self.name)
-
-
 class Group(TableBase):
     __tablename__ = 'groups'
     ident = Column(


### PR DESCRIPTION
_Part 1:_
Using autoincrement with composite primary key is [no longer supported](https://github.com/zzzeek/sqlalchemy/commit/414af7b61291b3fa77eb6da6a9b123399214089b#diff-79c290956ad49825a085d3073170ca03R862), and I am getting the following error when doing the update:
`sqlalchemy.exc.CompileError: (in table 'contacts', column 'id'): SQLite does not support autoincrement for composite primary keys`
As we do not really use the `Contacts` table, I have removed the primary key constraint from the role column. Please let me know if it had a specific purpose.

_Part 2_
**idle -> released (2)**

- brltty
limb, Gwyn Ciesla, [commit](https://src.fedoraproject.org/cgit/rpms/brltty.git/commit/brltty.spec?id=1ab2e779cb9fc6a9b9fcb4d538819fb286ef92f9)

- python-Lektor
cstratak, Charalampos Stratakis, [commit](https://src.fedoraproject.org/cgit/rpms/python-Lektor.git/commit/python-Lektor.spec?id=a5cb7e243ea66bcae5181b5d9284c578dfcd3867)

**mispackaged -> missing (1)**

- gnatcoll, no longer depends on Python (https://bugzilla.redhat.com/show_bug.cgi?id=1453185#c1)

**missing -> released (2)**

- fwupd
- python-blurb