### PR TITLE
check-specs script: Check if packages are built for epel

### DIFF
--- a/data/rhel-specs.json
+++ b/data/rhel-specs.json
@@ -1,0 +1,1838 @@
+{
+  "name-misnamed": {
+    "NLopt": [
+      "el6",
+      "epel7"
+    ],
+    "OpenImageIO": [
+      "el6",
+      "epel7"
+    ],
+    "PyPAM": [
+      "el6"
+    ],
+    "abrt": [],
+    "ansible": [
+      "el6",
+      "epel7"
+    ],
+    "atomic-reactor": [
+      "epel7"
+    ],
+    "boost": [],
+    "brltty": [],
+    "capstone": [
+      "epel7"
+    ],
+    "ceph": [
+      "el6",
+      "epel7"
+    ],
+    "cjdns": [
+      "el6",
+      "epel7"
+    ],
+    "claws-mail": [
+      "el6",
+      "epel7"
+    ],
+    "clearsilver": [
+      "el6",
+      "epel7"
+    ],
+    "criu": [],
+    "dmlite": [
+      "el6",
+      "epel7"
+    ],
+    "fedwatch": [
+      "el6",
+      "epel7"
+    ],
+    "file": [],
+    "firewalld": [],
+    "freeradius": [],
+    "fts-rest": [
+      "el6",
+      "epel7"
+    ],
+    "gdal": [
+      "el6",
+      "epel7"
+    ],
+    "gdl": [
+      "el6",
+      "epel7"
+    ],
+    "genders": [
+      "el6",
+      "epel7"
+    ],
+    "gfal2-python": [
+      "el6",
+      "epel7"
+    ],
+    "gofer": [
+      "el6",
+      "epel7"
+    ],
+    "graphviz": [],
+    "gtk-vnc": [],
+    "hamlib": [
+      "el6",
+      "epel7"
+    ],
+    "heketi": [
+      "el6",
+      "epel7"
+    ],
+    "ioprocess": [
+      "el6",
+      "epel7"
+    ],
+    "lash": [
+      "epel7"
+    ],
+    "lcgdm": [
+      "el6",
+      "epel7"
+    ],
+    "ledger": [
+      "el6",
+      "epel7"
+    ],
+    "lhapdf": [
+      "el6",
+      "epel7"
+    ],
+    "libbytesize": [],
+    "libcaca": [
+      "el6",
+      "epel7"
+    ],
+    "libgpod": [
+      "el6",
+      "epel7"
+    ],
+    "libhid": [],
+    "libiptcdata": [],
+    "liblinear": [
+      "el6",
+      "epel7"
+    ],
+    "liblouis": [],
+    "libpeas": [],
+    "libreport": [],
+    "libsmbios": [
+      "el6",
+      "epel7"
+    ],
+    "libsvm": [
+      "el6",
+      "epel7"
+    ],
+    "libwfut": [],
+    "lvm2": [],
+    "mirrorbrain": [
+      "el6",
+      "epel7"
+    ],
+    "nemo-extensions": [
+      "epel7"
+    ],
+    "nordugrid-arc": [
+      "el6",
+      "epel7"
+    ],
+    "openscap": [],
+    "osbs-client": [
+      "el6",
+      "epel7"
+    ],
+    "pcp": [
+      "el6"
+    ],
+    "pki-core": [],
+    "py-bcrypt": [
+      "el6",
+      "epel7"
+    ],
+    "pyatspi": [],
+    "pycscope": [],
+    "pyelftools": [
+      "el6",
+      "epel7"
+    ],
+    "pyflakes": [
+      "el6",
+      "epel7"
+    ],
+    "pyicu": [
+      "el6",
+      "epel7"
+    ],
+    "pymilia": [
+      "el6"
+    ],
+    "pyshp": [
+      "el6",
+      "epel7"
+    ],
+    "python-BeautifulSoup": [
+      "el6",
+      "epel7"
+    ],
+    "python-SocksiPy": [],
+    "python-alembic": [
+      "el6",
+      "epel7"
+    ],
+    "python-ansi2html": [],
+    "python-anykeystore": [
+      "el6",
+      "epel7"
+    ],
+    "python-anymarkup-core": [
+      "el6",
+      "epel7"
+    ],
+    "python-asciitable": [
+      "el6"
+    ],
+    "python-ase": [
+      "el6",
+      "epel7"
+    ],
+    "python-atfork": [
+      "el6"
+    ],
+    "python-auth-credential": [
+      "el6",
+      "epel7"
+    ],
+    "python-backports-ssl_match_hostname": [
+      "el6"
+    ],
+    "python-blessed": [
+      "epel7"
+    ],
+    "python-blist": [
+      "el6",
+      "epel7"
+    ],
+    "python-bugzilla": [
+      "el6",
+      "epel7"
+    ],
+    "python-bugzilla2fedmsg": [
+      "el6",
+      "epel7"
+    ],
+    "python-cairocffi": [
+      "el6",
+      "epel7"
+    ],
+    "python-caja": [
+      "epel7"
+    ],
+    "python-chameleon": [
+      "el6",
+      "epel7"
+    ],
+    "python-cherrypy": [
+      "el6",
+      "epel7"
+    ],
+    "python-cliff": [
+      "el6",
+      "epel7"
+    ],
+    "python-confparser": [
+      "el6"
+    ],
+    "python-contextlib2": [
+      "el6",
+      "epel7"
+    ],
+    "python-copr": [
+      "el6",
+      "epel7"
+    ],
+    "python-cpio": [
+      "el6"
+    ],
+    "python-crank": [
+      "epel7"
+    ],
+    "python-croniter": [
+      "el6",
+      "epel7"
+    ],
+    "python-cssmin": [
+      "el6",
+      "epel7"
+    ],
+    "python-d2to1": [
+      "el6",
+      "epel7"
+    ],
+    "python-datanommer-models": [
+      "el6",
+      "epel7"
+    ],
+    "python-debian": [
+      "el6",
+      "epel7"
+    ],
+    "python-di": [
+      "el6"
+    ],
+    "python-dirq": [
+      "el6",
+      "epel7"
+    ],
+    "python-django-angular": [
+      "epel7"
+    ],
+    "python-djvulibre": [
+      "el6",
+      "epel7"
+    ],
+    "python-docker-py": [
+      "el6",
+      "epel7"
+    ],
+    "python-easygui": [],
+    "python-enum34": [
+      "el6",
+      "epel7"
+    ],
+    "python-feedparser": [
+      "el6",
+      "epel7"
+    ],
+    "python-flask-login": [
+      "el6"
+    ],
+    "python-flask-rstpages": [
+      "el6",
+      "epel7"
+    ],
+    "python-fmn-consumer": [
+      "el6",
+      "epel7"
+    ],
+    "python-fmn-lib": [
+      "el6",
+      "epel7"
+    ],
+    "python-fmn-rules": [
+      "el6",
+      "epel7"
+    ],
+    "python-fmn-web": [
+      "el6",
+      "epel7"
+    ],
+    "python-gdata": [
+      "el6"
+    ],
+    "python-gensim": [
+      "el6",
+      "epel7"
+    ],
+    "python-geojson": [
+      "el6",
+      "epel7"
+    ],
+    "python-gerrit-view": [
+      "el6",
+      "epel7"
+    ],
+    "python-gertty": [],
+    "python-gzipstream": [
+      "el6"
+    ],
+    "python-halite": [
+      "el6"
+    ],
+    "python-httplib2": [
+      "el6",
+      "epel7"
+    ],
+    "python-hwdata": [
+      "el6"
+    ],
+    "python-isodate": [
+      "el6",
+      "epel7"
+    ],
+    "python-jsonpath-rw": [
+      "el6",
+      "epel7"
+    ],
+    "python-junitxml": [
+      "el6",
+      "epel7"
+    ],
+    "python-kazoo": [
+      "el6",
+      "epel7"
+    ],
+    "python-keystoneclient-kerberos": [],
+    "python-logbook": [
+      "epel7"
+    ],
+    "python-ly": [],
+    "python-lzo": [
+      "el6"
+    ],
+    "python-mako": [
+      "el6",
+      "epel7"
+    ],
+    "python-messaging": [
+      "el6",
+      "epel7"
+    ],
+    "python-mglob": [
+      "el6"
+    ],
+    "python-migrate": [
+      "el6",
+      "epel7"
+    ],
+    "python-moksha-common": [
+      "el6",
+      "epel7"
+    ],
+    "python-moksha-hub": [
+      "el6",
+      "epel7"
+    ],
+    "python-munch": [
+      "el6",
+      "epel7"
+    ],
+    "python-myghty": [
+      "epel7"
+    ],
+    "python-narcissus-hub": [
+      "el6",
+      "epel7"
+    ],
+    "python-nine": [
+      "el6",
+      "epel7"
+    ],
+    "python-odict": [
+      "el6"
+    ],
+    "python-openid": [
+      "el6",
+      "epel7"
+    ],
+    "python-openid-cla": [
+      "el6",
+      "epel7"
+    ],
+    "python-openid-teams": [
+      "el6",
+      "epel7"
+    ],
+    "python-openoffice": [
+      "el6",
+      "epel7"
+    ],
+    "python-ordered-set": [
+      "el6",
+      "epel7"
+    ],
+    "python-pathtools": [
+      "el6",
+      "epel7"
+    ],
+    "python-peak-util-addons": [
+      "epel7"
+    ],
+    "python-peak-util-assembler": [
+      "epel7"
+    ],
+    "python-peak-util-extremes": [
+      "epel7"
+    ],
+    "python-pgpdump": [
+      "el6",
+      "epel7"
+    ],
+    "python-postman": [
+      "el6"
+    ],
+    "python-pretty": [
+      "el6"
+    ],
+    "python-prettytable": [
+      "el6",
+      "epel7"
+    ],
+    "python-pycxx": [
+      "el6",
+      "epel7"
+    ],
+    "python-pymemcache": [
+      "epel7"
+    ],
+    "python-pypng": [
+      "el6",
+      "epel7"
+    ],
+    "python-pypump": [
+      "el6",
+      "epel7"
+    ],
+    "python-pyramid-chameleon": [
+      "el6",
+      "epel7"
+    ],
+    "python-pyramid-fas-openid": [
+      "epel7"
+    ],
+    "python-pytest-cov": [
+      "el6",
+      "epel7"
+    ],
+    "python-re2": [
+      "epel7"
+    ],
+    "python-recaptcha-client": [
+      "el6",
+      "epel7"
+    ],
+    "python-remoto": [
+      "el6",
+      "epel7"
+    ],
+    "python-repoze-tm2": [
+      "epel7"
+    ],
+    "python-repoze-who-plugins-sa": [
+      "epel7"
+    ],
+    "python-requests-mock": [
+      "el6",
+      "epel7"
+    ],
+    "python-retask": [
+      "el6",
+      "epel7"
+    ],
+    "python-rhsm": [
+      "el6"
+    ],
+    "python-robosignatory": [
+      "epel7"
+    ],
+    "python-ropemacs": [],
+    "python-rosinstall": [
+      "el6",
+      "epel7"
+    ],
+    "python-routes": [
+      "epel7"
+    ],
+    "python-rxjson": [
+      "el6",
+      "epel7"
+    ],
+    "python-scales": [
+      "el6",
+      "epel7"
+    ],
+    "python-shapely": [
+      "el6",
+      "epel7"
+    ],
+    "python-simplepath": [
+      "epel7"
+    ],
+    "python-simplevisor": [
+      "el6",
+      "epel7"
+    ],
+    "python-sippy": [
+      "el6"
+    ],
+    "python-socksipychain": [
+      "el6"
+    ],
+    "python-sparklines": [
+      "el6"
+    ],
+    "python-speaklater": [
+      "el6",
+      "epel7"
+    ],
+    "python-sphinx-autobuild": [
+      "epel7"
+    ],
+    "python-sphinx-theme-flask": [
+      "el6",
+      "epel7"
+    ],
+    "python-sphinxcontrib-cheeseshop": [
+      "el6",
+      "epel7"
+    ],
+    "python-sqlalchemy-utils": [],
+    "python-sqlite3dbm": [
+      "epel7"
+    ],
+    "python-sqlparse": [
+      "el6",
+      "epel7"
+    ],
+    "python-straight-plugin": [
+      "el6",
+      "epel7"
+    ],
+    "python-strainer": [
+      "el6",
+      "epel7"
+    ],
+    "python-summershum": [
+      "el6",
+      "epel7"
+    ],
+    "python-tahrir": [
+      "el6",
+      "epel7"
+    ],
+    "python-tahrir-api": [
+      "el6",
+      "epel7"
+    ],
+    "python-tambo": [
+      "el6",
+      "epel7"
+    ],
+    "python-taskw": [
+      "el6",
+      "epel7"
+    ],
+    "python-testtools": [
+      "el6",
+      "epel7"
+    ],
+    "python-tgmochikit": [
+      "el6",
+      "epel7"
+    ],
+    "python-trollius": [
+      "el6",
+      "epel7"
+    ],
+    "python-turbojson": [
+      "el6",
+      "epel7"
+    ],
+    "python-tw2-core": [
+      "el6",
+      "epel7"
+    ],
+    "python-tw2-d3": [
+      "el6"
+    ],
+    "python-tw2-dynforms": [
+      "el6",
+      "epel7"
+    ],
+    "python-tw2-forms": [
+      "el6",
+      "epel7"
+    ],
+    "python-tw2-jit": [
+      "el6",
+      "epel7"
+    ],
+    "python-tw2-jqplugins-flot": [
+      "el6",
+      "epel7"
+    ],
+    "python-tw2-jqplugins-gritter": [
+      "el6",
+      "epel7"
+    ],
+    "python-tw2-jqplugins-ui": [
+      "el6",
+      "epel7"
+    ],
+    "python-tw2-sqla": [
+      "el6",
+      "epel7"
+    ],
+    "python-txrequests": [
+      "epel7"
+    ],
+    "python-txws": [
+      "el6",
+      "epel7"
+    ],
+    "python-txzmq": [
+      "el6",
+      "epel7"
+    ],
+    "python-unidecode": [
+      "el6",
+      "epel7"
+    ],
+    "python-urllib2_kerberos": [
+      "el6",
+      "epel7"
+    ],
+    "python-urwid": [
+      "el6"
+    ],
+    "python-vcrpy": [
+      "epel7"
+    ],
+    "python-weberror": [
+      "epel7"
+    ],
+    "python-websocket-client": [
+      "el6",
+      "epel7"
+    ],
+    "python-wikitools": [
+      "el6",
+      "epel7"
+    ],
+    "python-wordpress-xmlrpc": [
+      "el6"
+    ],
+    "python-wsgiproxy": [],
+    "python-yolk": [
+      "el6"
+    ],
+    "python-zc-buildout": [
+      "el6",
+      "epel7"
+    ],
+    "python-zc-customdoctests": [
+      "el6"
+    ],
+    "python-zc-lockfile": [],
+    "python-zdaemon": [],
+    "qgis": [
+      "el6",
+      "epel7"
+    ],
+    "qpid-cpp": [
+      "el6",
+      "epel7"
+    ],
+    "qpid-proton": [
+      "el6",
+      "epel7"
+    ],
+    "redland-bindings": [
+      "el6"
+    ],
+    "remctl": [
+      "el6",
+      "epel7"
+    ],
+    "root": [
+      "el6",
+      "epel7"
+    ],
+    "rrdtool": [],
+    "samba": [],
+    "sanlock": [],
+    "satyr": [
+      "el6"
+    ],
+    "trademgen": [
+      "el6",
+      "epel7"
+    ],
+    "udiskie": [
+      "epel7"
+    ],
+    "unbound": [
+      "el6"
+    ],
+    "uwsgi": [
+      "el6",
+      "epel7"
+    ],
+    "v8": [
+      "el6",
+      "epel7"
+    ],
+    "vdsm": [
+      "el6",
+      "epel7"
+    ],
+    "vertica-python": [
+      "el6",
+      "epel7"
+    ],
+    "vigra": [],
+    "waf": [
+      "el6",
+      "epel7"
+    ],
+    "xrootd": [
+      "el6",
+      "epel7"
+    ],
+    "zanata-python-client": [
+      "el6",
+      "epel7"
+    ],
+    "zinnia": [
+      "el6",
+      "epel7"
+    ]
+  },
+  "require-misnamed": {
+    "ProDy": [
+      "el6",
+      "epel7"
+    ],
+    "Ray": [
+      "el6"
+    ],
+    "Spawning": [
+      "el6"
+    ],
+    "airinv": [
+      "el6",
+      "epel7"
+    ],
+    "airrac": [
+      "el6",
+      "epel7"
+    ],
+    "airtsp": [
+      "el6",
+      "epel7"
+    ],
+    "autojump": [
+      "el6",
+      "epel7"
+    ],
+    "autotest-framework": [
+      "el6",
+      "epel7"
+    ],
+    "autowrap": [
+      "epel7"
+    ],
+    "bitten": [
+      "el6",
+      "epel7"
+    ],
+    "bzr": [],
+    "certmaster": [
+      "el6",
+      "epel7"
+    ],
+    "cloud-utils": [
+      "el6",
+      "epel7"
+    ],
+    "cloudtoserver": [],
+    "comedilib": [
+      "el6"
+    ],
+    "createrepo_c": [
+      "el6",
+      "epel7"
+    ],
+    "crudini": [
+      "el6",
+      "epel7"
+    ],
+    "csmock": [
+      "el6",
+      "epel7"
+    ],
+    "drbdlinks": [
+      "el6",
+      "epel7"
+    ],
+    "dynafed": [
+      "el6",
+      "epel7"
+    ],
+    "espresso": [],
+    "etckeeper": [
+      "el6",
+      "epel7"
+    ],
+    "fedpkg": [
+      "el6",
+      "epel7"
+    ],
+    "func": [
+      "el6",
+      "epel7"
+    ],
+    "future": [
+      "el6",
+      "epel7"
+    ],
+    "geany-plugins": [
+      "el6",
+      "epel7"
+    ],
+    "gilmsg": [
+      "epel7"
+    ],
+    "gimp": [],
+    "git": [],
+    "glacier-cli": [
+      "el6"
+    ],
+    "glue-validator": [
+      "el6",
+      "epel7"
+    ],
+    "googsystray": [],
+    "grass": [
+      "el6",
+      "epel7"
+    ],
+    "grin": [
+      "el6",
+      "epel7"
+    ],
+    "gyp": [
+      "el6",
+      "epel7"
+    ],
+    "hg-git": [
+      "el6",
+      "epel7"
+    ],
+    "ikiwiki": [
+      "el6"
+    ],
+    "imgbased": [],
+    "json_diff": [
+      "el6"
+    ],
+    "jumpnbump": [
+      "epel7"
+    ],
+    "kobo": [
+      "el6",
+      "epel7"
+    ],
+    "libcomps": [
+      "el6",
+      "epel7"
+    ],
+    "librepo": [
+      "el6",
+      "epel7"
+    ],
+    "mach": [
+      "el6"
+    ],
+    "mock": [
+      "el6",
+      "epel7"
+    ],
+    "mpi4py": [
+      "el6",
+      "epel7"
+    ],
+    "nagios-plugins-fts": [
+      "el6"
+    ],
+    "netcdf4-python": [
+      "el6",
+      "epel7"
+    ],
+    "notmuch": [
+      "el6",
+      "epel7"
+    ],
+    "nut": [
+      "el6",
+      "epel7"
+    ],
+    "openmpi": [],
+    "pacemaker": [],
+    "pdc-client": [
+      "epel7"
+    ],
+    "plplot": [
+      "el6",
+      "epel7"
+    ],
+    "postgresql": [],
+    "py4j": [
+      "epel7"
+    ],
+    "pyflowtools": [],
+    "pyliblzma": [
+      "el6"
+    ],
+    "pynag": [
+      "el6",
+      "epel7"
+    ],
+    "python-Pympler": [],
+    "python-XStatic": [
+      "el6",
+      "epel7"
+    ],
+    "python-ZConfig": [],
+    "python-aniso8601": [
+      "el6",
+      "epel7"
+    ],
+    "python-argh": [
+      "el6",
+      "epel7"
+    ],
+    "python-assimulo": [
+      "epel7"
+    ],
+    "python-attrs": [
+      "epel7"
+    ],
+    "python-boto3": [
+      "el6",
+      "epel7"
+    ],
+    "python-botocore": [
+      "el6",
+      "epel7"
+    ],
+    "python-bz2file": [
+      "el6",
+      "epel7"
+    ],
+    "python-cached_property": [
+      "el6",
+      "epel7"
+    ],
+    "python-catkin_pkg": [
+      "el6",
+      "epel7"
+    ],
+    "python-certbot-apache": [
+      "epel7"
+    ],
+    "python-chai": [
+      "el6",
+      "epel7"
+    ],
+    "python-cov-core": [
+      "epel7"
+    ],
+    "python-decorator": [],
+    "python-defusedxml": [
+      "el6",
+      "epel7"
+    ],
+    "python-detox": [],
+    "python-django-rest-framework-composed-permissions": [],
+    "python-django-tastypie": [
+      "el6",
+      "epel7"
+    ],
+    "python-dulwich": [
+      "el6",
+      "epel7"
+    ],
+    "python-ecdsa": [
+      "el6",
+      "epel7"
+    ],
+    "python-evic": [
+      "epel7"
+    ],
+    "python-freezegun": [
+      "el6",
+      "epel7"
+    ],
+    "python-funcsigs": [
+      "epel7"
+    ],
+    "python-glusterfs-api": [],
+    "python-gnupg": [
+      "el6",
+      "epel7"
+    ],
+    "python-html2text": [
+      "el6",
+      "epel7"
+    ],
+    "python-httpbin": [
+      "el6",
+      "epel7"
+    ],
+    "python-idstools": [
+      "epel7"
+    ],
+    "python-ipython_genutils": [
+      "el6",
+      "epel7"
+    ],
+    "python-ivi": [
+      "el6",
+      "epel7"
+    ],
+    "python-jmespath": [
+      "el6",
+      "epel7"
+    ],
+    "python-manuel": [
+      "el6",
+      "epel7"
+    ],
+    "python-mock": [
+      "el6",
+      "epel7"
+    ],
+    "python-ngram": [
+      "el6",
+      "epel7"
+    ],
+    "python-nose": [],
+    "python-nose2": [
+      "epel7"
+    ],
+    "python-nose_fixes": [
+      "el6",
+      "epel7"
+    ],
+    "python-okaara": [
+      "el6",
+      "epel7"
+    ],
+    "python-paste-deploy": [
+      "epel7"
+    ],
+    "python-persistent": [],
+    "python-pika": [
+      "el6",
+      "epel7"
+    ],
+    "python-prompt_toolkit": [
+      "el6",
+      "epel7"
+    ],
+    "python-pybtex-docutils": [],
+    "python-pypandoc": [
+      "el6",
+      "epel7"
+    ],
+    "python-pystray": [],
+    "python-pytest-beakerlib": [],
+    "python-pytest-cache": [
+      "el6",
+      "epel7"
+    ],
+    "python-pytest-httpbin": [
+      "el6",
+      "epel7"
+    ],
+    "python-repoze-sphinx-autointerface": [
+      "el6",
+      "epel7"
+    ],
+    "python-requests_ntlm": [
+      "el6",
+      "epel7"
+    ],
+    "python-rsa": [
+      "el6",
+      "epel7"
+    ],
+    "python-s3transfer": [
+      "epel7"
+    ],
+    "python-scikit-image": [
+      "epel7"
+    ],
+    "python-scp": [
+      "el6",
+      "epel7"
+    ],
+    "python-semantic_version": [
+      "epel7"
+    ],
+    "python-simplegeneric": [
+      "el6",
+      "epel7"
+    ],
+    "python-speedtest-cli": [
+      "el6",
+      "epel7"
+    ],
+    "python-sphinx-bootstrap-theme": [
+      "el6",
+      "epel7"
+    ],
+    "python-stuf": [
+      "epel7"
+    ],
+    "python-testfixtures": [
+      "el6",
+      "epel7"
+    ],
+    "python-twiggy": [
+      "epel7"
+    ],
+    "python-unidiff": [
+      "el6",
+      "epel7"
+    ],
+    "python-vatnumber": [
+      "el6",
+      "epel7"
+    ],
+    "python-vxi11": [
+      "el6",
+      "epel7"
+    ],
+    "python-wcwidth": [
+      "el6",
+      "epel7"
+    ],
+    "python-whoosh": [
+      "el6",
+      "epel7"
+    ],
+    "python-yara": [
+      "el6",
+      "epel7"
+    ],
+    "python-zanata2fedmsg": [
+      "epel7"
+    ],
+    "python-zodbpickle": [],
+    "python-zope-dottedname": [],
+    "python-zope-schema": [
+      "el6",
+      "epel7"
+    ],
+    "python-zope-structuredtext": [],
+    "pytrailer": [],
+    "pyttsx": [
+      "el6"
+    ],
+    "rmol": [
+      "el6",
+      "epel7"
+    ],
+    "rpkg": [
+      "el6",
+      "epel7"
+    ],
+    "rpmdeplint": [
+      "epel7"
+    ],
+    "sagator": [
+      "el6",
+      "epel7"
+    ],
+    "scribus": [
+      "el6",
+      "epel7"
+    ],
+    "sevmgr": [
+      "el6",
+      "epel7"
+    ],
+    "shogun": [
+      "el6",
+      "epel7"
+    ],
+    "simcrs": [
+      "el6",
+      "epel7"
+    ],
+    "simfqt": [
+      "el6",
+      "epel7"
+    ],
+    "snake": [
+      "el6"
+    ],
+    "spacecmd": [
+      "el6",
+      "epel7"
+    ],
+    "stdair": [
+      "el6",
+      "epel7"
+    ],
+    "supybot-fedora": [
+      "el6",
+      "epel7"
+    ],
+    "systemtap": [],
+    "trac-bazaar-plugin": [
+      "el6"
+    ],
+    "trac-fedmsg-plugin": [
+      "el6"
+    ],
+    "trac-sensitivetickets-plugin": [
+      "el6"
+    ],
+    "travelccm": [
+      "el6",
+      "epel7"
+    ],
+    "trytond-calendar": [
+      "el6",
+      "epel7"
+    ],
+    "trytond-calendar-classification": [
+      "el6",
+      "epel7"
+    ],
+    "trytond-calendar-scheduling": [
+      "el6",
+      "epel7"
+    ],
+    "trytond-calendar-todo": [
+      "el6",
+      "epel7"
+    ],
+    "trytond-party-vcarddav": [
+      "el6",
+      "epel7"
+    ],
+    "ttname": [
+      "el6"
+    ],
+    "varnish": [
+      "el6",
+      "epel7"
+    ],
+    "waiverdb": [
+      "epel7"
+    ],
+    "weechat": [
+      "el6",
+      "epel7"
+    ],
+    "will-crash": [
+      "el6",
+      "epel7"
+    ],
+    "xorg-x11-drv-qxl": [],
+    "yum-utils": []
+  },
+  "require-blocked": {
+    "PyMca": [],
+    "TurboGears": [
+      "el6",
+      "epel7"
+    ],
+    "ailurus": [],
+    "avahi": [],
+    "batti": [],
+    "bdii": [
+      "el6",
+      "epel7"
+    ],
+    "beaker": [
+      "epel7"
+    ],
+    "blueberry": [
+      "epel7"
+    ],
+    "byobu": [
+      "el6",
+      "epel7"
+    ],
+    "caja-terminal": [
+      "epel7"
+    ],
+    "cas": [],
+    "ceph-deploy": [
+      "el6",
+      "epel7"
+    ],
+    "certbot": [
+      "el6",
+      "epel7"
+    ],
+    "cherrytree": [
+      "epel7"
+    ],
+    "childsplay": [],
+    "chromium": [
+      "epel7"
+    ],
+    "cinnamon": [
+      "epel7"
+    ],
+    "cobbler": [
+      "el6",
+      "epel7"
+    ],
+    "cockpit": [],
+    "copr-backend": [],
+    "copr-frontend": [],
+    "copr-keygen": [],
+    "createrepo": [],
+    "datagrepper": [
+      "el6",
+      "epel7"
+    ],
+    "datanommer-commands": [
+      "el6",
+      "epel7"
+    ],
+    "dnf": [
+      "epel7"
+    ],
+    "dnf-plugins-extras": [],
+    "dpm-contrib-admintools": [
+      "el6",
+      "epel7"
+    ],
+    "duplicity": [
+      "el6",
+      "epel7"
+    ],
+    "fedfind": [
+      "el6",
+      "epel7"
+    ],
+    "fedmsg": [
+      "el6",
+      "epel7"
+    ],
+    "fedocal": [
+      "el6"
+    ],
+    "fedora-packager": [
+      "el6",
+      "epel7"
+    ],
+    "fedora-review": [
+      "el6",
+      "epel7"
+    ],
+    "fedrepo-req": [
+      "epel7"
+    ],
+    "fleet-commander-admin": [],
+    "fleet-commander-client": [],
+    "flr": [
+      "epel7"
+    ],
+    "freecad": [
+      "el6",
+      "epel7"
+    ],
+    "freeipa": [],
+    "fts-monitoring": [
+      "el6",
+      "epel7"
+    ],
+    "github2fedmsg": [
+      "el6",
+      "epel7"
+    ],
+    "glusterfs": [
+      "el6"
+    ],
+    "gnumed-server": [],
+    "googlecl": [
+      "el6"
+    ],
+    "graphite-web": [
+      "el6",
+      "epel7"
+    ],
+    "grinder": [
+      "el6"
+    ],
+    "ibus": [],
+    "ibus-anthy": [
+      "epel7"
+    ],
+    "imagefactory": [
+      "el6",
+      "epel7"
+    ],
+    "imagefactory-plugins": [
+      "el6",
+      "epel7"
+    ],
+    "ipsilon": [
+      "epel7"
+    ],
+    "koji": [
+      "el6",
+      "epel7"
+    ],
+    "koji-containerbuild": [
+      "el6",
+      "epel7"
+    ],
+    "libblockdev": [
+      "epel7"
+    ],
+    "libgexiv2": [],
+    "libvirt-sandbox": [],
+    "livecd-tools": [
+      "el6",
+      "epel7"
+    ],
+    "loggerhead": [
+      "el6"
+    ],
+    "loopabull": [
+      "epel7"
+    ],
+    "memaker": [],
+    "mirrormanager2": [
+      "epel7"
+    ],
+    "module-build-service": [
+      "epel7"
+    ],
+    "modulemd": [
+      "el6",
+      "epel7"
+    ],
+    "mom": [
+      "el6",
+      "epel7"
+    ],
+    "nautilus-pastebin": [],
+    "nfs-ganesha": [
+      "el6",
+      "epel7"
+    ],
+    "nordugrid-arc-gangliarc": [
+      "el6",
+      "epel7"
+    ],
+    "nordugrid-arc-nagios-plugins": [
+      "el6",
+      "epel7"
+    ],
+    "odcs": [
+      "epel7"
+    ],
+    "osc": [
+      "el6"
+    ],
+    "packagedb-cli": [
+      "el6",
+      "epel7"
+    ],
+    "pagekite": [
+      "el6",
+      "epel7"
+    ],
+    "pagure": [
+      "epel7"
+    ],
+    "paraview": [
+      "el6",
+      "epel7"
+    ],
+    "pcl": [
+      "el6",
+      "epel7"
+    ],
+    "pkgwat": [
+      "el6",
+      "epel7"
+    ],
+    "pyexiv2": [
+      "el6",
+      "epel7"
+    ],
+    "pyhoca-cli": [
+      "el6",
+      "epel7"
+    ],
+    "pyhoca-gui": [
+      "el6",
+      "epel7"
+    ],
+    "pyqtrailer": [],
+    "pyrasite": [
+      "el6",
+      "epel7"
+    ],
+    "python-BTrees": [],
+    "python-ZEO": [],
+    "python-ZODB": [],
+    "python-ZODB3": [
+      "el6"
+    ],
+    "python-acme": [
+      "el6",
+      "epel7"
+    ],
+    "python-ansible-tower-cli": [
+      "el6",
+      "epel7"
+    ],
+    "python-anymarkup": [
+      "el6",
+      "epel7"
+    ],
+    "python-astroid": [
+      "el6",
+      "epel7"
+    ],
+    "python-astropy": [
+      "epel7"
+    ],
+    "python-autopep8": [],
+    "python-avocado": [
+      "el6",
+      "epel7"
+    ],
+    "python-behave": [
+      "el6",
+      "epel7"
+    ],
+    "python-biopython": [
+      "el6",
+      "epel7"
+    ],
+    "python-bitmath": [
+      "el6",
+      "epel7"
+    ],
+    "python-carbon": [
+      "el6",
+      "epel7"
+    ],
+    "python-cccolutils": [
+      "el6",
+      "epel7"
+    ],
+    "python-cornice": [
+      "el6",
+      "epel7"
+    ],
+    "python-docker": [],
+    "python-docker-squash": [
+      "epel7"
+    ],
+    "python-fedmsg-meta-fedora-infrastructure": [
+      "el6",
+      "epel7"
+    ],
+    "python-fedora": [
+      "el6",
+      "epel7"
+    ],
+    "python-flask-migrate": [
+      "epel7"
+    ],
+    "python-flask-restful": [
+      "el6",
+      "epel7"
+    ],
+    "python-flufl-bounce": [
+      "epel7"
+    ],
+    "python-jsonschema": [
+      "el6",
+      "epel7"
+    ],
+    "python-kdcproxy": [
+      "epel7"
+    ],
+    "python-kitchen": [
+      "el6",
+      "epel7"
+    ],
+    "python-matplotlib": [],
+    "python-networkx": [
+      "el6",
+      "epel7"
+    ],
+    "python-ntlm3": [
+      "el6",
+      "epel7"
+    ],
+    "python-oauth2client": [
+      "epel7"
+    ],
+    "python-oauthlib": [
+      "el6",
+      "epel7"
+    ],
+    "python-ofxparse": [
+      "el6",
+      "epel7"
+    ],
+    "python-ovirt-register": [
+      "el6",
+      "epel7"
+    ],
+    "python-paramiko": [
+      "el6",
+      "epel7"
+    ],
+    "python-parse_type": [
+      "el6",
+      "epel7"
+    ],
+    "python-pelican": [
+      "el6",
+      "epel7"
+    ],
+    "python-pybtex": [],
+    "python-pyrad": [
+      "el6",
+      "epel7"
+    ],
+    "python-pyramid": [
+      "el6",
+      "epel7"
+    ],
+    "python-pyramid-mako": [
+      "el6",
+      "epel7"
+    ],
+    "python-pytest-multihost": [],
+    "python-pytest-pep8": [
+      "el6",
+      "epel7"
+    ],
+    "python-pyvmomi": [
+      "el6",
+      "epel7"
+    ],
+    "python-requests": [
+      "el6",
+      "epel7"
+    ],
+    "python-rosdistro": [
+      "el6",
+      "epel7"
+    ],
+    "python-rospkg": [
+      "el6",
+      "epel7"
+    ],
+    "python-sprox": [
+      "el6"
+    ],
+    "python-structlog": [
+      "el6",
+      "epel7"
+    ],
+    "python-terminaltables": [],
+    "python-testify": [
+      "el6",
+      "epel7"
+    ],
+    "python-testresources": [
+      "el6",
+      "epel7"
+    ],
+    "python-tw2-jquery": [
+      "el6",
+      "epel7"
+    ],
+    "python-usbtmc": [
+      "el6",
+      "epel7"
+    ],
+    "python-vcstools": [
+      "el6",
+      "epel7"
+    ],
+    "pyvnc2swf": [
+      "el6"
+    ],
+    "qpid-dispatch": [
+      "el6",
+      "epel7"
+    ],
+    "radiotray": [],
+    "resiprocate": [
+      "el6",
+      "epel7"
+    ],
+    "rhn-client-tools": [],
+    "rhn-custom-info": [
+      "el6"
+    ],
+    "rpm-ostree-toolbox": [
+      "epel7"
+    ],
+    "s3cmd": [
+      "el6",
+      "epel7"
+    ],
+    "salt": [
+      "el6",
+      "epel7"
+    ],
+    "scitools": [
+      "el6"
+    ],
+    "seivot": [
+      "el6"
+    ],
+    "shinken": [
+      "el6",
+      "epel7"
+    ],
+    "sigul": [
+      "el6",
+      "epel7"
+    ],
+    "subscription-manager": [],
+    "subunit": [
+      "epel7"
+    ],
+    "system-config-firewall": [],
+    "system-config-users": [],
+    "telepathy-gabble": [
+      "el6"
+    ],
+    "terminator": [
+      "el6",
+      "epel7"
+    ],
+    "tracer": [
+      "epel7"
+    ],
+    "translation-filter": [
+      "el6"
+    ],
+    "tuned": [],
+    "virt-manager": [],
+    "virt-who": [],
+    "wicd": [
+      "el6"
+    ],
+    "wordgroupz": [],
+    "writetype": [
+      "el6"
+    ],
+    "xboxdrv": [
+      "el6",
+      "epel7"
+    ],
+    "yum": []
+  },
+  "generated_on": "2017-07-25 17:10:53.106076"
+}

--- a/scripts/check-specs.py
+++ b/scripts/check-specs.py
@@ -8,8 +8,11 @@ for rhel/epel.
 This check is pretty naive and gives just general information.
 It checks spec files for using `%if %{?rhel}` conditionals
 and may have false positives.
+
+Usage: ./scripts/check-specs.py
 """
 import click
+import json
 import logging
 import os
 import urllib.request
@@ -51,15 +54,36 @@ def check_spec(package):
     try:
         response = urllib.request.urlopen(spec_url)
     except urllib.error.URLError as err:
-        logger.error('Failed to get spec {}. Error: {}'.format(spec_url, err))
+        logger.error('Failed to get spec %s. Error: %s', spec_url, err)
     else:
         spec = str(response.read())
         for marker in MARKERS:
             if marker in spec:
-                logger.warning('{} uses {}: {}'.format(
-                    package.name, ', '.join(MARKERS), spec_url))
+                logger.warning('%s: %s', package.name, spec_url)
                 return package
-    logger.debug('Checked spec for {}: OK'.format(package.name))
+    logger.debug('Checked spec for %s: OK', package.name)
+
+
+def check_branches(package):
+    """Given the package, check if it is built for el6 or epel7.
+
+    Arguments:
+        - package (Package object)
+
+    Return: package if built for el6 or epel7, None otherwise
+    """
+    api_url = PKGDB_API.format(package.name)
+    try:
+        response = urllib.request.urlopen(api_url)
+    except urllib.error.URLError as err:
+        logger.error('Failed to get package info %s. Error: %s', api_url, err)
+    else:
+        response = response.read()
+        result = json.loads(response.decode())
+        branches = [pkg['collection']['branchname'] for pkg in result['packages']]
+        if 'el6' in branches or 'epel7' in branches:
+            logger.debug('%s has epel branch', package.name)
+            return package
 
 
 def check_packages(packages, check_function):
@@ -86,6 +110,7 @@ def main(db):
     db = get_portingdb(db)
     _, data = get_naming_policy_progress(db)
 
+    logger.info('Checking spec files for using %s...', ', '.join(MARKERS))
     result = {}
     for key, packages in data:
         result[key[0].ident] = check_packages(packages, check_spec)
@@ -94,11 +119,19 @@ def main(db):
     total_cross_platform = sum(len(packages) for packages in result.values())
     percentage = total_cross_platform * 100 / total
 
-    logger.info('Checking spec files')
+    logger.info('Checking for epel branches...')
+    pkgdb_result = {}
+    for category, packages in result.items():
+        pkgdb_result[category] = check_packages(packages, check_branches)
+
     print('\nPackages that use {} in spec files: {} of {} ({:.2f}%)'.format(
         ', '.join(MARKERS), total_cross_platform, total, percentage))
     for category, packages in result.items():
         print('  {}: {}'.format(category, len(packages)))
+
+    total_epel = sum(len(packages) for packages in pkgdb_result.values())
+    print('From those {}, have el6 or epel7 branch: {}'.format(
+        total_cross_platform, total_epel))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A follow up for #312
```
Packages that use %{?rhel} in spec files: 571 of 2338 (24.42%)
  name-misnamed: 240
  require-misnamed: 165
  require-blocked: 166
From those 571, have el6 or epel7 branch: 465
```