### PR TITLE
Mark packages that depend on unversioned /usr/bin/python

### DIFF
--- a/portingdb/templates/package.html
+++ b/portingdb/templates/package.html
@@ -76,6 +76,12 @@
                                                     <span class="fa fa-li"> </span>
                                                 {% endif %}
                                                 {{ pydep.name }}
+                                                {% if pydep.name == '/usr/bin/python' %}
+                                                    <span class="badge"
+                                                        style="background-color: #F0AD4E !important;"
+                                                        title="Scripts should explicitly use /usr/bin/python3 or /usr/bin/python2, especially in shebangs"
+                                                    >⅔</span>
+                                                {% endif %}
                                             </li>
                                         {% endfor %}
                                     </ul>


### PR DESCRIPTION
Add a marker like this:

![page-shot-2017-7-25 beakerlib python 3 porting database](https://user-images.githubusercontent.com/302922/28571171-e75da5d8-7141-11e7-8dc7-c633de4d2ad4.png)

I don't think a full tracking page is necessary – a simple repoquery is enough to get a list of these packages.