### PR TITLE
py3query.py: Track /usr/bin/env dependencies

### DIFF
--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -268,7 +268,7 @@ class Py3QueryCommand(dnf.cli.Command):
         # get extra dependencies
         extra_deps = ['/usr/bin/env']
         for dep in progressbar(extra_deps, 'Getting extra dependencies'):
-            for pkg in self.whatrequires(dep):
+            for pkg in self.whatrequires(dep, self.pkg_query):
                 if pkg in python_versions.keys():
                     rpm_pydeps[pkg].add('/usr/bin/env')
 

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -205,7 +205,7 @@ class Py3QueryCommand(dnf.cli.Command):
         # rpm_pydeps: {package: set of dep names}
         rpm_pydeps = collections.defaultdict(set)
         # dep_versions: {dep name: Python version}
-        dep_versions = collections.defaultdict(set)
+        dep_versions = collections.defaultdict(int)
         for n, seeds in SEED_PACKAGES.items():
             provides = sorted(self.all_provides(reponame, seeds), key=str)
 
@@ -264,6 +264,13 @@ class Py3QueryCommand(dnf.cli.Command):
                     requirer_srpm_name = hawkey.split_nevra(
                         pkg.sourcerpm).name if pkg.sourcerpm else pkg.name
                     unversioned_requirers[requirement_srpm_name].add(requirer_srpm_name)
+
+        # get extra dependencies
+        extra_deps = ['/usr/bin/env']
+        for dep in progressbar(extra_deps, 'Getting extra dependencies'):
+            for pkg in self.whatrequires(dep):
+                if pkg in python_versions.keys():
+                    rpm_pydeps[pkg].add('/usr/bin/env')
 
         # deps_of_pkg: {srpm name: info}
         json_output = dict()

--- a/portingdb/templates/package.html
+++ b/portingdb/templates/package.html
@@ -82,6 +82,12 @@
                                                         title="Scripts should explicitly use /usr/bin/python3 or /usr/bin/python2, especially in shebangs"
                                                     >⅔</span>
                                                 {% endif %}
+                                                {% if pydep.name == '/usr/bin/env' %}
+                                                    <span class="badge"
+                                                        style="background-color: #F0AD4E !important;"
+                                                        title="Scripts should not use /usr/bin/env in shebangs. Except in special circumstances, explicitly using /usr/bin/python3 or /usr/bin/python2 works better."
+                                                    >!</span>
+                                                {% endif %}
                                             </li>
                                         {% endfor %}
                                     </ul>


### PR DESCRIPTION
This is a bit of a hack -- the field is named "py_deps" but is now used to
track all specific dependencies (as opposed to SRPMs) that are useful to us.

Again, I tested the DNF plugin on f25, and cherry-picked. Please test on f26 too, before merging.