### PR TITLE
Add the `py3-only` status

### DIFF
--- a/data/statuses.yaml
+++ b/data/statuses.yaml
@@ -1,11 +1,23 @@
+- ident: py3-only
+  name: Python 3 only
+  abbrev: 🗹
+  color: '709966'
+  term: '\e[32;7m🗹\e[0m'
+  weight: 2
+  description: Package only supports Python 3
+  rank: 2
+  instructions:
+    Welcome to the future!
+    This package does not support Python 2 at all.
+    All is good in the world.
 - ident: released
   name: Released
   abbrev: ✔
   color: '5CB85C'
   term: '\e[32;7m✔\e[0m'
-  weight: 2
+  weight: 3
   description: Version with Python 3 support is officially released
-  rank: 2
+  rank: 3
   instructions:
     We are done! This package is released with Python 3 support, and
     all is good in the world.
@@ -14,9 +26,9 @@
   abbrev: P
   color: 'F0AD4E'
   term: '\e[33;7mP\e[0m'
-  weight: 6
+  weight: 7
   description: Actively worked on
-  rank: 5
+  rank: 6
   instructions:
     Someone is working on this package. Please coordinate with them.
 
@@ -27,9 +39,9 @@
   abbrev: M
   color: '5bc0de'
   term: M
-  weight: 5
+  weight: 6
   description: Packaging, rather than code, seems incorrect
-  rank: 6
+  rank: 7
   instructions: |
     This package has a packaging problem, which should be described in the
     notes.
@@ -42,9 +54,9 @@
   abbrev: I
   color: 'DDDDDD'
   term: ' '
-  weight: 4
+  weight: 5
   description: No current activity is recorded
-  rank: 4
+  rank: 5
   instructions: |
     No one is working on this package now. You can visit pkgdb for links to the
     upstream project.
@@ -57,9 +69,9 @@
   abbrev: B
   color: 'D9534F'
   term: 'B'
-  weight: 3
+  weight: 4
   description: Depends on work on another package
-  rank: 3
+  rank: 4
   instructions: |
     This package has some dependencies that do not support Python 3 yet.
     They need to be ported first.

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -137,6 +137,9 @@ def set_status(result, pkgs, python_versions):
             'Python 3.\n'
             'It should be split into a python2 and python3 subpackages '
             'to prevent it from always dragging the py2 dependency in.')
+    elif not name_by_version[2]:
+        # Hooray!
+        result['status'] = 'py3-only'
     else:
         # Otherwise, a srpm isn't ported if it has more packages that need py2
         # than those that need py3

--- a/docs/update_portingdb.rst
+++ b/docs/update_portingdb.rst
@@ -114,4 +114,6 @@ released -> idle
 
 * Let someone know.
 
+Treat the "py3-only" state the same as "released".
+
 If you encounter some other transition, let someone know and figure out a process!

--- a/portingdb/cli.py
+++ b/portingdb/cli.py
@@ -90,7 +90,8 @@ def print_status(ctx):
             total = sum(v for k, v in data.items())
             detail = ', '.join('{1} {0}'.format(k, v) for k, v in data.items())
             if total:
-                num_done = data.get('released', 0) + data.get('dropped', 0)
+                num_done = sum(data.get(s, 0)
+                               for s in ('released', 'dropped', 'py3-only'))
                 print('{score:5.1f}% {name}  ({detail}) / {total}'.format(
                     name=collection.name,
                     max_name_len=max_name_len,
@@ -175,7 +176,7 @@ def report(ctx):
         reqs = []
         for req in package.requirements:
             for cp in req.by_collection.values():
-                if cp.status != 'released':
+                if cp.status not in ('released', 'py3-only'):
                     reqs.append(req.name)
                     break
         if reqs:

--- a/portingdb/load.py
+++ b/portingdb/load.py
@@ -128,11 +128,13 @@ def _merge_updates(base, updates, warnings=None, parent_keys=()):
             _merge_updates(base[key], new_value, warnings,
                            parent_keys + (key, ))
         else:
-            if (warnings is not None and
-                        key == 'status' and
-                        base.get(key) == 'released'):
-                warnings.append(
-                    'overriding "released" status: ' + ': '.join(parent_keys))
+            for good_status in 'released', 'py3-only':
+                if (warnings is not None and
+                            key == 'status' and
+                            base.get(key) == good_status):
+                    warnings.append(
+                        'overriding "{}" status: {}'.format(
+                            good_status, ': '.join(parent_keys)))
             if (warnings is not None and
                         key == 'bug' and
                         base.get(key)):

--- a/portingdb/queries.py
+++ b/portingdb/queries.py
@@ -106,6 +106,7 @@ def update_status_summaries(db):
     depcp = aliased(tables.CollectionPackage)
     subquery = db.query(depcp)
     subquery = subquery.join(dep, depcp.package_name == dep.name)
+    subquery = subquery.filter(depcp.status != 'py3-only')
     subquery = subquery.filter(depcp.status != 'released')
     subquery = subquery.filter(depcp.status != 'dropped')
     subquery = subquery.filter(depcp.status != 'unknown')

--- a/portingdb/tables.py
+++ b/portingdb/tables.py
@@ -155,12 +155,12 @@ class Package(TableBase):
     @property
     def pending_requirements(self):
         return [r for r in self.requirements
-                if r.status not in ('released', 'dropped')]
+                if r.status not in ('released', 'dropped', 'py3-only')]
 
     @property
     def pending_requirers(self):
         return [r for r in self.requirers
-                if r.status not in ('released', 'dropped')]
+                if r.status not in ('released', 'dropped', 'py3-only')]
 
     @property
     def nonblocking(self):

--- a/portingdb/templates/history.html
+++ b/portingdb/templates/history.html
@@ -57,10 +57,12 @@ var colormap = {
     'blocked': '#D9534F',
     'released': '#5CB85C',
     'mispackaged': '#5BC0DE',
+    'py3-only': '#70E058',
     'dropped': '#888888',
 };
 
-var key_order = ["dropped", "released", "in-progress", "mispackaged", "idle", "blocked"];
+var key_order = ["dropped", "py3-only", "released", "in-progress",
+                 "mispackaged", "idle", "blocked"];
 
 chart("data.csv", colormap, key_order, {{ expand|tojson }});
 

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -157,10 +157,19 @@
             </ul>
             <h2 id="released">Released packages</h2>
             <div>
-                {{ len(done_packages) }}  packages are already ported. Yipee!
+                {{ len(released_packages) }}  packages are already ported. Yipee!
             </div>
             <div>
-               {% for pkg in done_packages %}
+               {% for pkg in released_packages %}
+                    {{ pkglink(pkg) }}
+               {% endfor %}
+            </div>
+            <h2 id="py3-only">Python3-only packages</h2>
+            <div>
+                {{ len(py3_only_packages) }} packages support Python 3 only. Yay!
+            </div>
+            <div>
+               {% for pkg in py3_only_packages %}
                     {{ pkglink(pkg) }}
                {% endfor %}
             </div>

--- a/scripts/get-history.py
+++ b/scripts/get-history.py
@@ -56,7 +56,7 @@ def get_history_package_numbers(db, commit, date):
     """
     prev_batch = []
     all_statuses = [
-        "blocked", "dropped", "idle", "in-progress", "released", "mispackaged"]
+        "blocked", "py3-only", "dropped", "idle", "in-progress", "released", "mispackaged"]
 
     columns = [tables.Package.status, func.count()]
     query = select(columns).select_from(tables.Package.__table__)


### PR DESCRIPTION
This adds an indication of which packages shouldn't be affected when Python 2 is dropped.