### PR TITLE
Pagure links (2nd change)

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -147,7 +147,7 @@ gnome-desktop:
       > on gobject introspection to bind to python.
 
       Note that since
-      [gnome-desktop3](https://admin.fedoraproject.org/pkgdb/package/rpms/gnome-desktop3/)
+      [gnome-desktop3](https://src.fedoraproject.org/rpms/gnome-desktop3/)
       uses GObject introspection, it has no own Python code and thus does not
       show up in PortingDB.
 gnome-python2:
@@ -311,7 +311,7 @@ pygtksourceview:
       Sugested replacement: `gtksourceview`
 
       Note that since
-      [gtksourceview](https://admin.fedoraproject.org/pkgdb/package/rpms/gtksourceview/)
+      [gtksourceview](https://src.fedoraproject.org/rpms/gtksourceview/)
       uses GObject introspection, it has no own Python code and thus does not
       show up in PortingDB.
 pyliblzma:
@@ -871,8 +871,8 @@ vegastrike-data: *vegastrike-cycle
 vte:
   status: dropped
   note: |
-    Replacement: [`vte3`](https://admin.fedoraproject.org/pkgdb/package/vte3/)
-    (Note that [vte3](https://admin.fedoraproject.org/pkgdb/package/vte3/) does
+    Replacement: [`vte3`](https://src.fedoraproject.org/rpms/vte3/)
+    (Note that [vte3](https://src.fedoraproject.org/rpms/vte3/) does
     not itself depend on Python, so it does not show up in portingdb).
 will-crash:
     status: released  # (exception)

--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -100,6 +100,7 @@ dpdk:
         Python 3 support committed but not yet released. (March 2016)
 dreampie:
     status: idle
+    is_misnamed: False
     note: |
         There's a python2 and a python3 subpackage, but they do different
         things. dreampie-python3 is a plugin to run python3 interpreter

--- a/portingdb/load.py
+++ b/portingdb/load.py
@@ -142,6 +142,11 @@ def _merge_updates(base, updates, warnings=None, parent_keys=()):
                     'overriding bug: {}: {}->{}'.format(
                         ': '.join(parent_keys), base.get(key), new_value))
 
+            # Override misnamed status for rpms in the package.
+            if key == 'is_misnamed':
+                for rpm in base.get('rpms', []):
+                    base['rpms'][rpm][key] = new_value
+
             base[key] = new_value
 
 

--- a/portingdb/templates/namingpolicy.html
+++ b/portingdb/templates/namingpolicy.html
@@ -61,7 +61,7 @@
                     <span class="pkgstatus-icon" style="background-color: {{ name_status.color }}">&nbsp;</span>&nbsp;{{ pkg[0] }}
                 </td>
                 <td>
-                    <a target="_blank" href="https://admin.fedoraproject.org/pkgdb/package/{{ pkg[0] }}/">PkgDB</a>,
+                    <a target="_blank" href="https://src.fedoraproject.org/rpms/{{ pkg[0] }}/">Pagure</a>,
                     <a target="_blank" href="https://src.fedoraproject.org/rpms/{{ pkg[0] }}/blob/master/f/{{ pkg[0] }}.spec">spec</a>
                 </td>
             </tr>

--- a/portingdb/templates/package.html
+++ b/portingdb/templates/package.html
@@ -26,9 +26,9 @@
             <div>
                 <img src="https://fedoraproject.org/static/images/favicon.ico">
                 See
-                <a href="https://admin.fedoraproject.org/pkgdb/package/{{ pkg.name }}/">
+                <a href="https://src.fedoraproject.org/rpms/{{ pkg.name }}/">
                     {{ pkg.name }}</a>
-                in the Fedora Package Database, or go directly to the corresponding
+                in the Fedora Pagure, or go directly to the corresponding
                 <a href="https://src.fedoraproject.org/rpms/{{ pkg.name }}/blob/master/f/{{ pkg.name }}.spec">spec file</a>.
             </div>
         </div>


### PR DESCRIPTION
- Use Pagure links instead of PkgDB (not only for spec files)
- Override misnamed status for `dreampie` as it is not misnamed (also make it possible to override misnamed status for a package in `fedora-update.yaml`)