### PR TITLE
Update info for non-packagers

### DIFF
--- a/portingdb/templates/howto.html
+++ b/portingdb/templates/howto.html
@@ -39,7 +39,7 @@
         </p>
         <h3>Open a Pull Request</h3>
         <p>
-            In either case, look a bit further down on the package page in PortingDB and find a link to the associated Bugzilla report (under <i>Links→bug</i> in the sidebar). Go there and join the discussion. Find out what's the status quo and if anyone is working on it. If not, be the one that opens a Pagure pull request with a fix! The link to the package repository in Fedora Pagure is right next to the Fedora logo on top of the package page in PortingDB (if you are not a Fedora packager yet, you may use remote pull requests).
+            In either case, look a bit further down on the package page in PortingDB and find a link to the associated Bugzilla report (under <i>Links→bug</i> in the sidebar). Go there and join the discussion. Find out what's the status quo and if anyone is working on it. If not, be the one that opens a Pagure pull request with a fix! The link to the package repository in Fedora Pagure is right next to the Fedora logo on top of the package page in PortingDB (if you are not a Fedora packager yet, you may use remote pull requests or attach a patch to the Bugzilla ticket).
         </p><p>
             If you don't find a link to Bugzilla, you'll need to investigate the issue and <a href="https://fedoraproject.org/wiki/User:Pviktori/Python_3_Bug_Filing">file a bug</a> yourself. A hint on the nature of the problem will usually be provided just under the Fedora heading on the package page.
         </p><p>


### PR DESCRIPTION
Allow remote PRs as well as Bugzilla patches for non-packagers.

As per [comments to #333](https://github.com/fedora-python/portingdb/issues/333#issuecomment-329825448)