### PR TITLE
Don't mark packages that depend on themselves as blocked

### DIFF
--- a/portingdb/queries.py
+++ b/portingdb/queries.py
@@ -113,6 +113,7 @@ def update_status_summaries(db):
     subquery = subquery.filter(~depcp.nonblocking)
     subquery = subquery.join(tables.Dependency, tables.Dependency.requirement_name == dep.name)
     subquery = subquery.filter(tables.Dependency.requirer_name == tables.Package.name)
+    subquery = subquery.filter(tables.Dependency.requirer_name != tables.Dependency.requirement_name)
 
     update = main_update
     update = update.where(subquery.exists())


### PR DESCRIPTION
Normally the Dependency table doesn't include self-dependencies (i.e. a package that depends on itself, or a subpackage of the same SRPM).
However, we always record *unversioned* dependencies.

Filter out the self-dependencies when assigning the 'blocked' status.