### PR TITLE
Fix a reference to the old term "Misnamed Requires"

### DIFF
--- a/data/naming.yaml
+++ b/data/naming.yaml
@@ -23,7 +23,7 @@
     needed.
     <div><strong>Note!</strong> Some of these packages may also use the
     wrong naming scheme in (Build)Requires, thus they fall into
-    <i>Misnamed Requires</i> category as well. However they are displayed
+    <i>Ambiguous Requires</i> category as well. However they are displayed
     here, because fixing a misnamed subpackage has a higher priority.</div>
 - ident: require-misnamed
   name: Ambiguous Requires


### PR DESCRIPTION
The category is now called "Ambiguous Requires" elsewhere in the UI

Related to commit 8e12a96fc255ebd4b96f966a297db50bacd7c10b