### PR TITLE
Mark python2-django1.11 as dropped

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -453,6 +453,15 @@ python2-docs:
     status: dropped
     note: |
         Replacement: `python3-docs`
+python2-django1.11:
+    status: dropped
+    note: |
+        Compatibility package for libraries needed by *applications* that
+        cannot switch to Python 3 just yet.
+
+        See [the "Django 2.0" change for Fedora 28](https://fedoraproject.org/wiki/Changes/Django20).
+
+        Replacement: `python-django`
 python-elixir:
     status: dropped
     note: |


### PR DESCRIPTION
This is compat package [heading for Rawhide](https://koji.fedoraproject.org/koji/taskinfo?taskID=24400283). Please merge as soon as it appears in portingdb.