### PR TITLE
Mark git as nonblocking

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -129,6 +129,7 @@ fwfstab:
     dead-upstream: true
 git:
     status: idle
+    nonblocking: true
     note: |
         `git-core` uses Python 3, however `git-p4` is still Python 2 only.
 glade3:


### PR DESCRIPTION
The missing package, git-p4, is an import/interoperability tool
and isn't required by anything else in Fedora.