### PR TITLE
Remove the `in-progress` status and the "Where porting happens" sidebar

### DIFF
--- a/data/collections.yaml
+++ b/data/collections.yaml
@@ -3,9 +3,6 @@
   description: |
     Official repositories, mailing lists or issue trackers of the given projects.
   statuses:
-    in-progress: |
-      Patches for Python 3 support are being reviewed; or it is already merged
-      in a development branch but not released.
     released: |
       There's an official release that includes Python 3 support.
 - ident: fedora
@@ -17,8 +14,6 @@
       The package will not be ported.
       All packages depending on it must switch to an alternative that supports
       Python 3.
-    in-progress: |
-      A spec that includes Python 3 support is being updated, written or tested.
     released: |
       A package that supports Python 3 is in Rawhide.
     mispackaged: |

--- a/data/statuses.yaml
+++ b/data/statuses.yaml
@@ -21,19 +21,6 @@
   instructions:
     We are done! This package is released with Python 3 support, and
     all is good in the world.
-- ident: in-progress
-  name: In Progress
-  abbrev: P
-  color: 'F0AD4E'
-  term: '\e[33;7mP\e[0m'
-  weight: 7
-  description: Actively worked on
-  rank: 6
-  instructions:
-    Someone is working on this package. Please coordinate with them.
-
-    (If you cannot find contacts here, please
-    [file a bug](https://github.com/fedora-python/portingdb/issues))
 - ident: mispackaged
   name: Mispackaged
   abbrev: M

--- a/portingdb/htmlreport.py
+++ b/portingdb/htmlreport.py
@@ -131,7 +131,6 @@ def hello():
         breadcrumbs=(
             (url_for('hello'), 'Python 3 Porting Database'),
         ),
-        collections=collections,
         coll_info=coll_info,
         statuses=statuses,
         priorities=list(db.query(tables.Priority).order_by(tables.Priority.order)),

--- a/portingdb/load.py
+++ b/portingdb/load.py
@@ -55,11 +55,14 @@ def decode_file(filename):
 
 
 def _get_pkg(name, collection, info):
+    status = info.get('status') or 'unknown'
+    if status == 'in-progress':
+        raise ValueError(name + ": the `in-progress` status should not be used")
     return {
         'package_name': name,
         'collection_ident': collection,
         'name': info.get('aka') or name,
-        'status': info.get('status') or 'unknown',
+        'status': status,
         'is_misnamed': info.get('is_misnamed'),
         'priority': info.get('priority') or 'unknown',
         'deadline': info.get('deadline', None),

--- a/portingdb/templates/graph.html
+++ b/portingdb/templates/graph.html
@@ -48,7 +48,7 @@
         <h1>A Graph</h1>
         <p>
             Here is a graph showing all dependency relationships for unported
-            packages (idle, blocked, mispackaged, and in-progress)
+            packages (idle, blocked, and mispackaged)
             {% if grp %}
                 in the <a href='{{ url_for("group", grp=grp) }}'>{{ grp }}</a>
                 group

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -241,43 +241,6 @@
                 </li>
                 {% endfor %}
             </ul>
-            <h2>Where Porting Happens</h2>
-            {% for col in collections %}
-                {% set total = coll_info[col]['total'] %}
-                <h3>{{ col.name }}</h3>
-                <div class="progress">
-                    {% for status in statuses %}
-                        {% set num = coll_info[col]['data'].get(status.ident, 0) %}
-                        {% if num %}
-                            <div
-                                class="progress-bar" role="progressbar"
-                                aria-valuenow="{{ num }}"
-                                aria-valuemin="0" aria-valuemax="{{ total }}"
-                                style="width: {{ 100 * num / total }}%;
-                                       background-color: #{{ status.color }} !important;
-                                       color: black;"
-                            >
-                            </div>
-                        {% endif %}
-                    {% endfor %}
-                </div>
-                <div>{{ col.description }}</div>
-                <ul class="list-group">
-                    {% for status in statuses %}
-                        {% set num = coll_info[col]['data'].get(status.ident, 0) %}
-                        {% if num %}
-                            <li class="list-group-item">
-                                {{ num }}
-                                {{ badge(status) }}
-                                <strong>{{ status.name }}</strong>
-                                <div><small>
-                                    {{ col.status_description(status) }}
-                                </small></div>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
-                </ul>
-            {% endfor %}
             {% if 'extra-sidebar' in config %}
                 {{ config['extra-sidebar'] |safe }}
             {% endif %}

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -64,16 +64,6 @@
                     </div>
                 {% endfor %}
             {% endif %}
-            {% if active_packages %}
-                <h2 id="in-progress">Porting in Progress</h2>
-                <div>
-                    We know about {{ len(active_packages) }} packages that
-                    someone is actively porting, or which are waiting for review.
-                </div>
-                <table class="table table-striped table-condensed table-hovered">
-                {{ pkglist_table_content(active_packages, collections) }}
-                </table>
-            {% endif %}
             {% if mispackaged_packages %}
                 <h2 id="mispackaged">Mispackaged packages</h2>
                 <div>

--- a/portingdb/templates/package.html
+++ b/portingdb/templates/package.html
@@ -13,15 +13,6 @@
             <div style="border-left: 4px solid #{{pkg.status_obj.color}}; padding-left: 4px; ">
                 {{ pkg.status_obj.instructions | md }}
             </div>
-            {% if in_progress_deps and pkg.status != 'in-progress' %}
-                <div style="border-left: 4px solid #F0AD4E; padding-left: 4px; ">
-                    Some projects this package depends on are currently being
-                    ported, so you might need to use their development versions.
-                    Please coordinate with
-                    {% for p in in_progress_deps %}
-                        {{ pkglink_text(p) }}{% if not loop.last %},{% endif %}{% endfor %}.
-                </div>
-            {% endif %}
             <br>
             <div>
                 <img src="https://fedoraproject.org/static/images/favicon.ico">


### PR DESCRIPTION
These seemed like good ideas at the time, but weren't.
The in-progress status stays in history; it was used until late 2016.