### PR TITLE
Load build dependencies into the database

### DIFF
--- a/portingdb/cli.py
+++ b/portingdb/cli.py
@@ -170,12 +170,12 @@ def report(ctx):
     query = db.query(tables.Package)
     query = query.order_by(func.lower(tables.Package.name))
     query = query.options(eagerload(tables.Package.by_collection))
-    query = query.options(subqueryload(tables.Package.requirements))
+    query = query.options(subqueryload(tables.Package.run_time_requirements))
     for package in query:
         print_collection_info(package, collections)
         print(' ' + package.name, end=' ')
         reqs = []
-        for req in package.requirements:
+        for req in package.run_time_requirements:
             for cp in req.by_collection.values():
                 if cp.status not in ('released', 'legacy-leaf', 'py3-only'):
                     reqs.append(req.name)
@@ -262,7 +262,7 @@ def deps(ctx, package, exclude, trim, skip, graph):
             e = '✔'
         else:
             seen.add(pkg)
-            reqs = [p for p in pkg.requirements if p is not pkg]
+            reqs = [p for p in pkg.run_time_requirements if p is not pkg]
             if skip:
                 reqs = [r for r in reqs
                         if not (can_ignore(r) or r.name in exclude)]

--- a/portingdb/htmlreport.py
+++ b/portingdb/htmlreport.py
@@ -230,11 +230,11 @@ def package(pkg):
         dependencies=dependencies,
         dependents=dependents,
         deptree=[(package, gen_deptree(dependencies))],
+        dependencies_status_counts=get_status_counts(dependencies),
         build_dependencies=build_dependencies,
         build_dependents=build_dependents,
         build_deptree=[(package, gen_deptree(build_dependencies, run_time=False, build_time=True))],
-        len_dependencies=len(dependencies),
-        dependencies_status_counts=get_status_counts(dependencies),
+        build_dependencies_status_counts=get_status_counts(build_dependencies),
     )
 
 

--- a/portingdb/htmlreport.py
+++ b/portingdb/htmlreport.py
@@ -270,7 +270,7 @@ def group(grp):
         grp=group,
         packages=packages,
         len_packages=len(packages),
-        deptree=list(gen_deptree(seed_groups)),
+        deptree=list(gen_deptree(seed_groups, run_time=True, build_time=True)),
         status_counts=get_status_counts(packages),
     )
 
@@ -283,8 +283,8 @@ def gen_deptree(base, *, seen=None, run_time=True, build_time=False):
             yield pkg, []
         else:
             reqs = sorted(
-                set(pkg.run_time_requirements if run_time else [] +
-                    pkg.build_time_requirements if build_time else []),
+                set((pkg.run_time_requirements if run_time else []) +
+                    (pkg.build_time_requirements if build_time else [])),
                 key=lambda p: (-p.status_obj.weight, p.name))
             yield pkg, gen_deptree(reqs, seen=seen | {pkg},
                                    run_time=run_time, build_time=build_time)

--- a/portingdb/queries.py
+++ b/portingdb/queries.py
@@ -162,7 +162,7 @@ def update_group_closures(db):
             if pkg not in pkgs:
                 pkgs.add(pkg)
                 if pkg.status not in ('dropped', ):
-                    waiting.update(pkg.run_time_requirements)
+                    waiting.update(pkg.requirements)
         pkgs.difference_update(group.packages)
         values.extend({'group_ident': group.ident, 'package_name': p.name}
                       for p in pkgs)

--- a/portingdb/queries.py
+++ b/portingdb/queries.py
@@ -38,9 +38,8 @@ def order_by_weight(db, query):
     return query
 
 
-def _deps(db, package, forward=True):
+def _deps(db, package, forward=True, run_time=True, build_time=False):
     query = packages(db)
-    package_table = aliased(tables.Package)
 
     if forward:
         col_a = tables.Dependency.requirement_name
@@ -50,6 +49,10 @@ def _deps(db, package, forward=True):
         col_b = tables.Dependency.requirement_name
     query = query.outerjoin(tables.Dependency, col_a == tables.Package.name)
     query = query.filter(col_b == package.name)
+
+    query = query.filter(
+        or_(tables.Dependency.run_time == run_time,
+            tables.Dependency.build_time == build_time))
 
     query = query.join(tables.Status, tables.Status.ident == tables.Package.status)
     query = query.order_by(-tables.Status.weight)
@@ -64,6 +67,14 @@ def dependencies(db, package):
 
 def dependents(db, package):
     return _deps(db, package, False)
+
+
+def build_dependencies(db, package):
+    return _deps(db, package, True, False, True)
+
+
+def build_dependents(db, package):
+    return _deps(db, package, False, False, True)
 
 
 def order_by_name(db, query):
@@ -115,6 +126,7 @@ def update_status_summaries(db):
     subquery = subquery.join(tables.Dependency, tables.Dependency.requirement_name == dep.name)
     subquery = subquery.filter(tables.Dependency.requirer_name == tables.Package.name)
     subquery = subquery.filter(tables.Dependency.requirer_name != tables.Dependency.requirement_name)
+    subquery = subquery.filter(tables.Dependency.run_time)
 
     update = main_update
     update = update.where(subquery.exists())
@@ -150,7 +162,7 @@ def update_group_closures(db):
             if pkg not in pkgs:
                 pkgs.add(pkg)
                 if pkg.status not in ('dropped', ):
-                    waiting.update(pkg.requirements)
+                    waiting.update(pkg.run_time_requirements)
         pkgs.difference_update(group.packages)
         values.extend({'group_ident': group.ident, 'package_name': p.name}
                       for p in pkgs)

--- a/portingdb/templates/package.html
+++ b/portingdb/templates/package.html
@@ -195,10 +195,20 @@
         <div class="col-md-1"></div>
         <div class="col-md-8">
             <h2>Dependencies</h2>
+            <h4>Run time</h4>
             {{ progress_summary_legend(dependencies_status_counts.items()) }}
             {% if dependencies %}
                 <table class="table table-striped table-condensed table-hovered">
                     {{ pkglist_table_content(dependencies, collections, show_nonblocking=1) }}
+                </table>
+            {% else %}
+                None.
+            {% endif %}
+            <h4>Build time</h4>
+            {{ progress_summary_legend(build_dependencies_status_counts.items()) }}
+            {% if build_dependencies %}
+                <table class="table table-striped table-condensed table-hovered">
+                    {{ pkglist_table_content(build_dependencies, collections, show_nonblocking=1) }}
                 </table>
             {% else %}
                 None.

--- a/portingdb/templates/package.html
+++ b/portingdb/templates/package.html
@@ -122,6 +122,7 @@
                 {% endif %}
             {% endfor %}
             <h3>Dependent packages</h3>
+            <h4>Run time</h4>
             {% if dependents %}
                 <ul class="simple-pkg-list">
                     {% for pkg in dependents %}
@@ -131,8 +132,21 @@
             {% else %}
                 None.
             {% endif %}
+            <h4>Build time</h4>
+            {% if build_dependents %}
+                <ul class="simple-pkg-list">
+                    {% for pkg in build_dependents %}
+                        <li>{{ pkglink(pkg) }}</li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                None.
+            {% endif %}
             <h3>Dependency Tree</h3>
+            <h4>Run time</h4>
             {{ print_deptree(deptree) }}
+            <h4>Build time</h4>
+            {{ print_deptree(build_deptree) }}
             {% if pkg['loc_total'] %}
                 <h3>Project Size</h3>
                 {{ loc_chart(pkg) }}


### PR DESCRIPTION
* On the package page, categorize dependencies into build time and run time
![image](https://user-images.githubusercontent.com/5603118/37030479-66a6e5b2-213b-11e8-9698-3ea98a94ffcf.png)

* Add relationships for build and run time dependencies separately:
`package.run_time_requirements`, and `package.build_time_requirements`

So far build dependencies are only being shown on the package page left panel in `Dependent packages` and `Dependency tree` to showcase. They can also be displayed in the `Dependencies` sections, on Groups page etc. Also only run time dependencies are so far favored when deciding which packages are Blocked or when building a dependency graph.

Scope of #382