### PR TITLE
3 changes

### DIFF
--- a/portingdb/load.py
+++ b/portingdb/load.py
@@ -325,6 +325,12 @@ def load_from_directories(db, directories):
                   key_columns=['rpm_id', 'py_dependency_name'])
 
     group_values = data_from_file(directories, 'groups')
+    try:
+        more_groups = data_from_file(directories, 'groups-update')
+    except FileNotFoundError:
+        pass
+    else:
+        group_values = {**group_values, **more_groups}
     values = [{
         'ident': k,
         'name': v['name'],

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -157,7 +157,7 @@
             <h2 id="legacy-leaf">Packages with leaf Python 2 subpackages</h2>
             <div>
                 The Python 2 versions of {{ len(legacy_leaf_packages) }} packages
-                are not required by anything else in Fedora.
+                are not required by anything else we track.
                 The subpackages can be dropped if the maintainer wishes.
             </div>
             <div>

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -147,7 +147,8 @@
             </ul>
             <h2 id="released">Packages with dual support</h2>
             <div>
-                {{ len(released_packages) }} packages support both Python 2 and 3. Yipee!
+                {{ len(released_packages) }} packages support both Python 2 and 3.
+                Half-way there!
             </div>
             <div>
                {% for pkg in released_packages %}


### PR DESCRIPTION
Three unrelated changes:

* Allow a `groups-update` file
* Remove a mention of Fedora in the main template
* Don't celebrate dual py2/py3 support

Sending as one PR to cut down on bureaucracy, but I can split them if one is controversial.