### PR TITLE
Option to load both run and build time deps on the graph

### DIFF
--- a/portingdb/htmlreport.py
+++ b/portingdb/htmlreport.py
@@ -375,16 +375,18 @@ def graph_json(grp=None, pkg=None):
             package = todo.pop()
             if package not in requirements:
                 requirements.add(package)
-                todo.update(p for p in package.run_time_requirements
-                            if p.status not in DONE_STATUSES)
+                todo.update(p for p in package.requirements
+                            if p.status not in DONE_STATUSES and
+                            not p.nonblocking)
         todo = {root_package}
         requirers = set()
         while todo:
             package = todo.pop()
             if package not in requirers:
                 requirers.add(package)
-                todo.update(p for p in package.run_time_requirers
-                            if p.status not in DONE_STATUSES)
+                todo.update(p for p in package.requirers
+                            if p.status not in DONE_STATUSES and
+                            not p.nonblocking)
         packages = list(requirements | requirers | {root_package})
 
     package_names = {p.name for p in packages}

--- a/portingdb/templates/graph.html
+++ b/portingdb/templates/graph.html
@@ -67,6 +67,29 @@
             Bigger nodes mean more Python (+C extension) code.
         </p>
         <p>
+            {% if all_deps %}
+                Both build time and run time dependencies are displayed on the graph. You can 
+                {% if grp %}
+                    <a href="{{ url_for('graph_grp', grp=grp) }}">
+                {% elif pkg %}
+                    <a href="{{ url_for('graph_pkg', pkg=pkg) }}">
+                {% else %}
+                    <a href="{{ url_for('graph') }}">
+                {% endif %}
+                load run time dependencies only</a>.
+            {% else %}
+                The graph shows only run time dependencies. To see a bigger picture
+                {% if grp %}
+                    <a href="{{ url_for('graph_grp', grp=grp, all_deps=1) }}">
+                {% elif pkg %}
+                    <a href="{{ url_for('graph_pkg', pkg=pkg, all_deps=1) }}">
+                {% else %}
+                    <a href="{{ url_for('graph', all_deps=1) }}">
+                {% endif %}
+                load build time dependencies</a> as well.
+            {% endif %}
+        </p>
+        <p>
             Large graphs are quite CPU-hungry. Sorry for that!
         </p>
     </div>
@@ -92,11 +115,11 @@ var svg = d3.select("#graph-goes-here").append("svg")
 
 d3.json(
     {% if grp %}
-        "{{ url_for('graph_json_grp', grp=grp) }}"
+        "{{ url_for('graph_json_grp', grp=grp, all_deps=all_deps) }}"
     {% elif pkg %}
-        "{{ url_for('graph_json_pkg', pkg=pkg) }}"
+        "{{ url_for('graph_json_pkg', pkg=pkg, all_deps=all_deps) }}"
     {% else %}
-        "portingdb.json"
+        "{{ url_for('graph_json', all_deps=all_deps) }}"
     {% endif %}
     , function(error, graph) {
   if (error) throw error;


### PR DESCRIPTION
Fixes #402 

Default behavior when opening graph page:
![image](https://user-images.githubusercontent.com/5603118/38096074-42ce3746-3372-11e8-99b8-0cc68488d132.png)

Clicking on "load build time deps as well" (see asciidoc cluster)
![screenshot from 2018-03-29 16-50-18](https://user-images.githubusercontent.com/5603118/38096145-720fec34-3372-11e8-8506-0155496f5282.png)
