### PR TITLE
python-cloudfiles no longer has an upstream

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -385,6 +385,11 @@ python-cherrypy2:
       This is a backwards compatibility package.  Code that needs to be run on
       python3 needs to be ported to a current version of this framework.
       Replacement: `python3-cherrypy`
+python-cloudfiles:
+    status: dropped
+    note: |
+        Upstream no longer exists.
+        Suggested replacement: `python3-swiftclient`
 python-cssmin:
     status: dropped
     note: |


### PR DESCRIPTION
It's still on [PyPI](https://pypi.org/project/python-cloudfiles/), but the upstream is now a private repo.  Before it went private, the README was updated to this:

```
python-cloudfiles
=================

IMPORTANT NOTE:
The python-cloudfiles bindings are no longer being maintained and their
use is deprecated. They will not be available after August 1, 2013.

We recommend that you use the pyrax bindings; this supports
all of the Rackspace cloud products, and not just Cloud Files.
See http://docs.rackspace.com/sdks/guide/content/python.html to download or to contribute.


Please also see https://github.com/openstack/python-swiftclient for the official swift OpenStack Bindings.
```

