### PR TITLE
 Don't make CLOSED NOTABUG and similar bugs mark packages mispackaged 

### DIFF
--- a/data/fedora.json
+++ b/data/fedora.json
@@ -2938,7 +2938,6 @@
         "2016-03-01 10:06:46"
       ]
     },
-    "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
     "rpms": {
       "python2-antlr-2.7.7-55.fc29": {
         "legacy_leaf": false,
@@ -2951,7 +2950,7 @@
         }
       }
     },
-    "status": "mispackaged"
+    "status": "idle"
   },
   "anyremote": {
     "build_deps": [
@@ -9328,7 +9327,6 @@
         "2018-04-04 09:30:20"
       ]
     },
-    "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
     "rpms": {
       "python2-cracklib-2.9.6-15.fc29": {
         "legacy_leaf": false,
@@ -9343,7 +9341,7 @@
         }
       }
     },
-    "status": "mispackaged"
+    "status": "idle"
   },
   "createrepo": {
     "build_deps": [
@@ -12591,7 +12589,6 @@
         "2017-04-04 09:49:02"
       ]
     },
-    "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
     "rpms": {
       "emacs-pymacs-0.25-8.fc25": {
         "legacy_leaf": true,
@@ -12606,7 +12603,7 @@
         }
       }
     },
-    "status": "mispackaged",
+    "status": "idle",
     "tracking_bugs": [
       "https://bugzilla.redhat.com/show_bug.cgi?id=1312032"
     ]
@@ -137614,7 +137611,6 @@
         "2016-04-22 15:30:23"
       ]
     },
-    "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
     "rpms": {
       "vte-0.28.2-26.fc29": {
         "legacy_leaf": false,
@@ -137641,7 +137637,7 @@
         }
       }
     },
-    "status": "mispackaged"
+    "status": "idle"
   },
   "vtk": {
     "build_deps": [

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -45,6 +45,8 @@ ADDITIONAL_TRACKER_BUGS = [
     1333770,  # PY3PATCH-PUSH
     1432186,  # Missing PY3-EXECUTABLES
 ]
+# Bugzilla statuses that indicate the bug was filed in error
+NOTABUG_STATUSES = {'CLOSED NOTABUG', 'CLOSED WONTFIX', 'CLOSED CANTFIX'}
 
 # Template URL to which you can add the bug ID and get a working URL
 BUGZILLA_BUG_URL = "https://bugzilla.redhat.com/show_bug.cgi?id={}"
@@ -385,7 +387,8 @@ class Py3QueryCommand(dnf.cli.Command):
                             BUGZILLA_BUG_URL.format(tb))
 
                 if (any(tb in bug.blocks for tb in MISPACKAGED_TRACKER_BUG_IDS) and
-                        r.get('status') == 'idle'):
+                        r.get('status') == 'idle' and
+                        status not in NOTABUG_STATUSES):
                     r['status'] = "mispackaged"
                     r['note'] = ('There is a problem in Fedora packaging, '
                                  'not necessarily with the software itself. '


### PR DESCRIPTION
We've accumulated some py3 porting bugs that were filed in error,
but they're still marking stuff as mispackaged.

Ignore bugs closed as NOTABUG, WONTFIX and CANTFIX.