### PR TITLE
Remove PY3PATCH-REQUESTED and simplify (disable) /mispackaged

### DIFF
--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -40,7 +40,6 @@ MISPACKAGED_TRACKER_BUG_IDS = [
 # Trackers of bugs whose presence gives us additional information about the
 # status quo.
 ADDITIONAL_TRACKER_BUGS = [
-    1333765,  # PY3PATCH-REQUESTED
     1312032,  # PY3PATCH-AVAILABLE
     1333770,  # PY3PATCH-PUSH
     1432186,  # Missing PY3-EXECUTABLES

--- a/portingdb/templates/howto.html
+++ b/portingdb/templates/howto.html
@@ -27,7 +27,6 @@
             There are currently <a href="{{ url_for('hello', _anchor='mispackaged') }}">{{ mispackaged }} packages</a> that are Python 3–ready upstream (that we know of), but not quite yet Python 3–ready in Fedora. These are labeled as "mispackaged" in PortingDB.
         </p><p>
             You can view the <a href="{{ url_for('hello', _anchor='mispackaged') }}">mispackaged packages</a> ordered by their last activity, so you can pick one off the top and be relatively sure nobody is currently working on it.
-            Alternatively, you can pick one of <a href="{{ url_for('mispackaged', requested=1) }}">these packages</a>, where the packager explicitly asked for someone to provide a patch since they don't have the time for it.
         </p><p>
             Now open the package in PortingDB (e.g. {{ pkglink(random_mispackaged) }}): The {{ status_badge(statuses['mispackaged']) }} in the sidebar indicates that indeed we are dealing with a mispackaged package.
         </p>

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -68,13 +68,6 @@
                 <div>
                     {{ len(mispackaged_packages) }} packages were found to have some kind of packaging problem.
                 </div>
-                <div style="padding-bottom: 7pt">
-                    You can also see <a href="{{
-                    url_for('mispackaged', requested=1) }}">only packages for which the
-                    maintainer requested a patch</a>.<br/>
-                    For more information read: <a href="{{ url_for('howto')
-                    }}">So you want to contribute?</a>
-                </div>
                 <table class="table table-striped table-condensed table-hovered">
                     <tr>
                         <th>Package</th>
@@ -85,10 +78,6 @@
                     <tr>
                         <td>
                             {{ pkglink(pkg) }}
-                            {% if "https://bugzilla.redhat.com/show_bug.cgi?id=1333765"
-                                  in pkg.tracking_bugs %}
-                            (patch requested by maintainer)
-                            {% endif %}
                         </td>
                         <td>
                             {% if pkg.last_link_update %}

--- a/portingdb/templates/mispackaged.html
+++ b/portingdb/templates/mispackaged.html
@@ -9,16 +9,9 @@
 <div class="container">
     <div class="col-md-12">
         <h1>Mispackaged</h1>
-        {% if requested %}
-            <p>
-                Mispackaged packages for which the maintainer requested a patch.
-                Ordered by last activity.
-            </p>
-        {% else %}
             <p>
                 All mispackaged packages, ordered by last activity.
             </p>
-        {% endif %}
 
         {% if not mispackaged %}
         <p>
@@ -36,11 +29,6 @@
             <tr>
                 <td>
                     {{ pkglink(pkg) }}
-                    {% if not requested and
-                            "https://bugzilla.redhat.com/show_bug.cgi?id=1333765"
-                            in pkg.list_tracking_bugs %}
-                       (patch requested by maintainer)
-                    {% endif %}
                 </td>
                 <td>
                     {% if pkg.last_link_update %}


### PR DESCRIPTION
I've closed the [PY3PATCH-REQUESTED] bugzilla, as this seems it
doesn't need tracking any more. We can deal with porting specs
to py3 individually.

[PY3PATCH-REQUESTED]: https://bugzilla.redhat.com/show_bug.cgi?id=1333765

This removes references to it, and also the `/mispackaged?requested=1`
page (which doesn't get frozen, and AFAICS has been empty for over a year).