### PR TITLE
Track subpackages with "python" in the name

### DIFF
--- a/data/fedora.json
+++ b/data/fedora.json
@@ -492,7 +492,9 @@
       "libevent",
       "python3"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "links": {
       "bug": [
         "https://bugzilla.redhat.com/show_bug.cgi?id=1323243",
@@ -526,6 +528,7 @@
     "deps": [
       "python-AppTools",
       "python-envisage",
+      "python-pyface",
       "python-traitsui",
       "python2",
       "vtk"
@@ -675,6 +678,7 @@
   },
   "OpenImageIO": {
     "build_deps": [
+      "boost",
       "python3"
     ],
     "deps": [
@@ -1026,6 +1030,15 @@
           "python(abi) = 3.7": 3
         }
       },
+      "python3-PyQt4-devel-4.12.3-3.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-PyQt4-webkit-4.12.3-3.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -1169,6 +1182,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-PyXB-doc-1.2.6-4.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-PyXB-1.2.6-4.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -1180,6 +1202,15 @@
           "/usr/bin/python3": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-PyXB-doc-1.2.6-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -1425,6 +1456,7 @@
   },
   "Singular": {
     "build_deps": [
+      "boost",
       "polymake",
       "python2"
     ],
@@ -2154,7 +2186,9 @@
     "build_deps": [
       "python3"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "rpms": {
       "adonthell-0.3.6-10.fc29": {
         "almost_leaf": false,
@@ -2288,6 +2322,7 @@
   },
   "airinv": {
     "build_deps": [
+      "boost",
       "python2"
     ],
     "deps": [
@@ -2338,6 +2373,7 @@
   },
   "airrac": {
     "build_deps": [
+      "boost",
       "python2"
     ],
     "deps": [
@@ -2362,6 +2398,7 @@
   },
   "airtsp": {
     "build_deps": [
+      "boost",
       "python2"
     ],
     "deps": [
@@ -2779,7 +2816,8 @@
     ],
     "deps": [
       "git",
-      "glade"
+      "glade",
+      "python3"
     ],
     "rpms": {
       "anjuta-1:3.28.0-7.fc30": {
@@ -3008,6 +3046,7 @@
   },
   "antimony": {
     "build_deps": [
+      "boost",
       "python3",
       "qt5-qtbase"
     ],
@@ -3563,6 +3602,7 @@
   },
   "assimp": {
     "build_deps": [
+      "python-rpm-macros",
       "python2",
       "python3"
     ],
@@ -3689,9 +3729,7 @@
           "build_time": [
             "gap-pkg-hap"
           ],
-          "run_time": [
-            "texlive"
-          ]
+          "run_time": []
         },
         "py_deps": {
           "/usr/bin/python3": 3
@@ -4174,6 +4212,7 @@
     "build_deps": [
       "dbus-python",
       "python-inotify",
+      "python-qt5",
       "python-setuptools",
       "python-xlib",
       "python3",
@@ -4368,6 +4407,7 @@
   },
   "avogadro": {
     "build_deps": [
+      "boost",
       "numpy",
       "python2",
       "sip"
@@ -4418,6 +4458,7 @@
   },
   "avogadro2-libs": {
     "build_deps": [
+      "boost",
       "python3",
       "qt5-qtbase"
     ],
@@ -5220,7 +5261,6 @@
           ],
           "run_time": [
             "bontmia",
-            "check-mk",
             "clamav-unofficial-sigs",
             "gnome-nettool",
             "inxi",
@@ -5462,7 +5502,8 @@
     "deps": [
       "OpenColorIO",
       "numpy",
-      "python-requests"
+      "python-requests",
+      "python3"
     ],
     "rpms": {
       "blender-1:2.79b-8.fc30": {
@@ -5944,6 +5985,7 @@
     "deps": [
       "mpich",
       "numpy",
+      "openmpi",
       "python2",
       "python3"
     ],
@@ -5974,6 +6016,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "boost-mpich-python2-devel-1.66.0-14.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "boost-mpich-python3-1.66.0-14.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -5985,6 +6036,15 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "boost-mpich-python3-devel-1.66.0-14.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "boost-numpy2-1.66.0-14.fc29": {
         "almost_leaf": true,
@@ -6020,6 +6080,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "boost-openmpi-python2-devel-1.66.0-14.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "boost-openmpi-python3-1.66.0-14.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -6032,6 +6101,15 @@
           "python(abi) = 3.7": 3
         }
       },
+      "boost-openmpi-python3-devel-1.66.0-14.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "boost-python2-1.66.0-14.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -6043,6 +6121,15 @@
           "libpython2.7.so.1.0()(64bit)": 2
         }
       },
+      "boost-python2-devel-1.66.0-14.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "boost-python3-1.66.0-14.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -6053,6 +6140,17 @@
         "py_deps": {
           "libpython3.7m.so.1.0()(64bit)": 3
         }
+      },
+      "boost-python3-devel-1.66.0-14.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [
+            "libndn-cxx"
+          ],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "idle"
@@ -6151,6 +6249,7 @@
   },
   "botan": {
     "build_deps": [
+      "boost",
       "python-sphinx",
       "python3"
     ],
@@ -6470,7 +6569,8 @@
   },
   "btrbk": {
     "build_deps": [
-      "asciidoc"
+      "asciidoc",
+      "python-rpm-macros"
     ],
     "deps": [],
     "rpms": {
@@ -6559,6 +6659,7 @@
   },
   "bugzilla": {
     "build_deps": [
+      "python-rpm-macros",
       "python-sphinx",
       "python2"
     ],
@@ -6851,12 +6952,14 @@
   },
   "calamares": {
     "build_deps": [
+      "boost",
       "kf5-ki18n",
       "python3",
       "qt5-qtbase"
     ],
     "deps": [
-      "boost"
+      "boost",
+      "python3"
     ],
     "rpms": {
       "calamares-libs-3.1.8-10.fc29": {
@@ -6958,7 +7061,8 @@
       "qt5-qtbase"
     ],
     "deps": [
-      "python2"
+      "python2",
+      "python3"
     ],
     "links": {
       "bug": [
@@ -7576,6 +7680,15 @@
           "/usr/bin/python2.7": 2
         }
       },
+      "python-ceph-compat-1:12.2.8-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python-cephfs-1:12.2.8-1.fc30": {
         "almost_leaf": true,
         "is_misnamed": true,
@@ -7881,6 +7994,25 @@
           "python2": 2,
           "python2 = 2.7.15-10.fc30": 2
         }
+      }
+    },
+    "status": "idle"
+  },
+  "check-mk": {
+    "build_deps": [
+      "python-setuptools",
+      "python2"
+    ],
+    "deps": [],
+    "rpms": {
+      "python2-cmk-1.4.0p31-4.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "idle"
@@ -8292,6 +8424,7 @@
   "clang": {
     "build_deps": [
       "python-lit",
+      "python-rpm-macros",
       "python-sphinx",
       "python3"
     ],
@@ -8936,7 +9069,9 @@
       "python3",
       "varnish"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "rpms": {
       "collectd-python-5.8.0-16.fc29": {
         "almost_leaf": false,
@@ -9575,6 +9710,7 @@
       "python-jinja2",
       "python-munch",
       "python-requests",
+      "python-rpm-macros",
       "python-setuptools",
       "python3",
       "rpm"
@@ -9998,6 +10134,7 @@
   },
   "csdiff": {
     "build_deps": [
+      "boost",
       "python3"
     ],
     "deps": [
@@ -10144,6 +10281,15 @@
           "python2": 2,
           "python2 = 2.7.15-10.fc30": 2
         }
+      },
+      "python2-csound-devel-6.10.0-2.fc28": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "idle"
@@ -10661,6 +10807,17 @@
       "python3"
     ],
     "rpms": {
+      "dbus-python-devel-1.2.8-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [
+            "gedit-plugins"
+          ],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-dbus-1.2.8-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -10708,6 +10865,9 @@
     "status": "released",
     "unversioned_requirers": [
       "cherrytree",
+      "gedit-plugins",
+      "ibus",
+      "prepaid-manager-applet",
       "telepathy-haze",
       "variety"
     ]
@@ -11394,6 +11554,7 @@
   },
   "dlib": {
     "build_deps": [
+      "boost",
       "python3"
     ],
     "deps": [
@@ -11494,6 +11655,7 @@
   },
   "dmlite": {
     "build_deps": [
+      "boost",
       "python2"
     ],
     "deps": [
@@ -12857,6 +13019,7 @@
   "ecryptfs-utils": {
     "build_deps": [
       "glib2",
+      "python-rpm-macros",
       "python2"
     ],
     "deps": [
@@ -12990,6 +13153,7 @@
   },
   "electron-cash": {
     "build_deps": [
+      "python-qt5",
       "python3"
     ],
     "deps": [
@@ -13025,6 +13189,7 @@
   },
   "electrum": {
     "build_deps": [
+      "python-qt5",
       "python3"
     ],
     "deps": [
@@ -13284,7 +13449,6 @@
             "lrcalc",
             "meataxe",
             "mp",
-            "openmpi",
             "pmix",
             "rpm-mpi-hooks",
             "slurm",
@@ -13959,6 +14123,7 @@
       "python-psutil",
       "python-pygments",
       "python-requests",
+      "python-rpm-macros",
       "python-setuptools",
       "python-six",
       "python-sphinx",
@@ -16165,6 +16330,7 @@
     "build_deps": [
       "pyside-tools",
       "python-pycxx",
+      "python-pyside",
       "python2",
       "shiboken"
     ],
@@ -16260,6 +16426,15 @@
         "py_deps": {
           "/usr/bin/python3": 3
         }
+      },
+      "freeipa-python-compat-4.7.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "freeipa-server-4.7.1-1.fc30": {
         "almost_leaf": false,
@@ -16401,6 +16576,7 @@
   },
   "freeorion": {
     "build_deps": [
+      "boost",
       "python2"
     ],
     "deps": [
@@ -17325,9 +17501,37 @@
       "python-lxml",
       "python-pygments",
       "python-six",
-      "python2"
+      "python2",
+      "python3"
     ],
     "rpms": {
+      "gcc-python-plugin-c-api-0.16-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "gcc-python-plugin-docs-0.16-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "gcc-python2-debug-plugin-0.16-6.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "gcc-python2-plugin-0.16-6.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -17338,6 +17542,15 @@
         "py_deps": {
           "libpython2.7.so.1.0()(64bit)": 2
         }
+      },
+      "gcc-python3-debug-plugin-0.16-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "gcc-python3-plugin-0.16-6.fc29": {
         "almost_leaf": false,
@@ -17351,7 +17564,10 @@
         }
       }
     },
-    "status": "legacy-leaf"
+    "status": "legacy-leaf",
+    "unversioned_requirers": [
+      "gcc-python-plugin"
+    ]
   },
   "gcompris": {
     "build_deps": [
@@ -17473,7 +17689,9 @@
     "build_deps": [
       "python3"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "rpms": {
       "gdb-headless-8.2.50.20181010-5.fc30": {
         "almost_leaf": false,
@@ -17916,6 +18134,7 @@
   },
   "gfal2-python": {
     "build_deps": [
+      "boost",
       "epydoc",
       "python2",
       "python3"
@@ -17933,6 +18152,15 @@
       ]
     },
     "rpms": {
+      "gfal2-python-doc-1.9.4-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "gfal2-python3-1.9.4-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -18161,6 +18389,7 @@
       "python-QtPy",
       "python-astropy",
       "python-astropy-helpers",
+      "python-matplotlib",
       "python-qt5",
       "python3",
       "scipy"
@@ -18168,6 +18397,7 @@
     "deps": [
       "python-QtPy",
       "python-astropy",
+      "python-matplotlib",
       "python-qt5",
       "python3",
       "scipy"
@@ -18195,6 +18425,15 @@
           "/usr/bin/python3": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-ginga-examples-2.7.1-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -18538,6 +18777,7 @@
   },
   "git-cola": {
     "build_deps": [
+      "PyQt4",
       "git",
       "python-sphinx",
       "python3"
@@ -18982,7 +19222,9 @@
       "itstool",
       "python3"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "rpms": {
       "glade-libs-3.22.1-3.fc29": {
         "almost_leaf": false,
@@ -20165,6 +20407,7 @@
   },
   "glom": {
     "build_deps": [
+      "boost",
       "itstool",
       "python3"
     ],
@@ -20922,9 +21165,19 @@
       "python2"
     ],
     "deps": [
+      "gnome-python2",
       "python2"
     ],
     "rpms": {
+      "gnome-python2-desktop-2.32.0-34.fc30": {
+        "almost_leaf": true,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "gnome-python2-gnomekeyring-2.32.0-34.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -20976,6 +21229,15 @@
       "python2"
     ],
     "rpms": {
+      "gnome-python2-extras-2.25.3-53.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "gnome-python2-gtkspell-2.25.3-53.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -22243,7 +22505,9 @@
       "glib2",
       "python3"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "rpms": {
       "gplugin-loader-python-0.27.0-9.fc29": {
         "almost_leaf": false,
@@ -23019,10 +23283,20 @@
     ],
     "deps": [
       "libxml2",
+      "pygobject2",
       "pygtk2",
       "python2"
     ],
     "rpms": {
+      "gstreamer-python-devel-0.10.22-19.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-gstreamer-0.10.22-19.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -23043,12 +23317,14 @@
     },
     "status": "idle",
     "unversioned_requirers": [
+      "gstreamer-rtsp",
       "turpial"
     ]
   },
   "gstreamer-rtsp": {
     "build_deps": [
       "gobject-introspection",
+      "gstreamer-python",
       "pygobject2",
       "python2"
     ],
@@ -24445,7 +24721,9 @@
       "meson",
       "python3"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "rpms": {
       "hexchat-2.14.2-1.fc30": {
         "almost_leaf": false,
@@ -25152,6 +25430,7 @@
   "ibus": {
     "build_deps": [
       "GConf2",
+      "dbus-python",
       "git",
       "gobject-introspection",
       "gtk-doc",
@@ -25275,6 +25554,7 @@
   },
   "ibus-bogo": {
     "build_deps": [
+      "PyQt4",
       "pygobject3",
       "python3"
     ],
@@ -26040,7 +26320,9 @@
     "build_deps": [
       "python3"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "rpms": {
       "insight-8.1.50.20180216-6.fc29": {
         "almost_leaf": false,
@@ -26415,6 +26697,15 @@
           "/usr/bin/python3": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-ipython-doc-7.0.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "python3-ipython-sphinx-7.0.1-1.fc30": {
         "almost_leaf": false,
@@ -27062,6 +27353,7 @@
   "jpype": {
     "build_deps": [
       "python-mock",
+      "python-rpm-macros",
       "python-setuptools",
       "python-sphinx",
       "python-sphinx_rtd_theme",
@@ -27153,6 +27445,7 @@
   "k3d": {
     "build_deps": [
       "asciidoc",
+      "boost",
       "python2"
     ],
     "deps": [
@@ -27246,6 +27539,7 @@
   "kcachegrind": {
     "build_deps": [
       "kf5-ki18n",
+      "python-rpm-macros",
       "qt5-qtbase"
     ],
     "deps": [],
@@ -27310,7 +27604,9 @@
       "python3",
       "qt5-qtbase"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "rpms": {
       "kdevelop-python-5.2.80-1.py3.fc30": {
         "almost_leaf": false,
@@ -27957,6 +28253,7 @@
   },
   "kig": {
     "build_deps": [
+      "boost",
       "kf5-ki18n",
       "python2",
       "qt5-qtbase"
@@ -28457,6 +28754,7 @@
   "konversation": {
     "build_deps": [
       "kf5-ki18n",
+      "python-rpm-macros",
       "python3",
       "qt5-qtbase"
     ],
@@ -29341,6 +29639,7 @@
   },
   "ledger": {
     "build_deps": [
+      "boost",
       "python2"
     ],
     "deps": [
@@ -29849,6 +30148,15 @@
       "python3"
     ],
     "rpms": {
+      "python-libcomps-doc-0.1.8-14.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-libcomps-0.1.8-14.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -29923,6 +30231,24 @@
       }
     },
     "status": "idle"
+  },
+  "libdnet": {
+    "build_deps": [
+      "python3"
+    ],
+    "deps": [],
+    "rpms": {
+      "python3-libdnet-1.12-29.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      }
+    },
+    "status": "released"
   },
   "libdnf": {
     "build_deps": [
@@ -30097,6 +30423,7 @@
     "build_deps": [
       "dbus-python",
       "python-enum34",
+      "python-qt5",
       "python2",
       "scons"
     ],
@@ -30453,6 +30780,15 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-pygpu-devel-0.7.6-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -30788,6 +31124,7 @@
   },
   "libldb": {
     "build_deps": [
+      "libtalloc",
       "libtdb",
       "libtevent",
       "python2",
@@ -30806,6 +31143,15 @@
       ]
     },
     "rpms": {
+      "python-ldb-devel-common-1.4.2-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-ldb-1.4.2-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -30818,6 +31164,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-ldb-devel-1.4.2-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-ldb-1.4.2-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -30829,11 +31184,23 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-ldb-devel-1.4.2-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released",
     "tracking_bugs": [
       "https://bugzilla.redhat.com/show_bug.cgi?id=1312032"
+    ],
+    "unversioned_requirers": [
+      "libldb"
     ]
   },
   "liblinear": {
@@ -31086,7 +31453,8 @@
       "python3"
     ],
     "deps": [
-      "pygobject3"
+      "pygobject3",
+      "python3"
     ],
     "rpms": {
       "libpeas-loader-python3-1.22.0-9.fc29": {
@@ -32196,6 +32564,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-talloc-devel-2.1.14-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-talloc-2.1.14-2.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -32207,6 +32584,15 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-talloc-devel-2.1.14-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -32328,6 +32714,7 @@
   },
   "libtevent": {
     "build_deps": [
+      "libtalloc",
       "python2",
       "python3"
     ],
@@ -32860,10 +33247,7 @@
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
-          "build_time": [
-            "python2-docs",
-            "python3-docs"
-          ],
+          "build_time": [],
           "run_time": []
         },
         "py_deps": {
@@ -32921,6 +33305,7 @@
       "dbus-python",
       "dnf",
       "libselinux",
+      "lorax",
       "pykickstart",
       "pyparted",
       "python-six",
@@ -32938,6 +33323,15 @@
         "py_deps": {
           "/usr/bin/python3": 3
         }
+      },
+      "python-imgcreate-sysdeps-1:25.0-11.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "python2-imgcreate-1:25.0-11.fc30": {
         "almost_leaf": false,
@@ -32962,7 +33356,10 @@
         }
       }
     },
-    "status": "released"
+    "status": "released",
+    "unversioned_requirers": [
+      "livecd-tools"
+    ]
   },
   "lizardfs": {
     "build_deps": [
@@ -35746,6 +36143,7 @@
       "python3-cherrypy"
     ],
     "deps": [
+      "python-matplotlib",
       "python-pillow",
       "python-pyopengl",
       "python-qt5",
@@ -36360,6 +36758,7 @@
     ],
     "deps": [
       "mpich",
+      "openmpi",
       "python2",
       "python3"
     ],
@@ -37020,7 +37419,9 @@
       "python2",
       "python3"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "links": {
       "bug": [
         "https://bugzilla.redhat.com/show_bug.cgi?id=1636626",
@@ -37047,6 +37448,15 @@
           "libpython3.7m.so.1.0()(64bit)": 3
         }
       },
+      "python2-nautilus-devel-1.2.1-3.fc30": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-nautilus-1.2.1-3.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -37057,9 +37467,18 @@
         "py_deps": {
           "libpython3.7m.so.1.0()(64bit)": 3
         }
+      },
+      "python3-nautilus-devel-1.2.1-3.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
-    "status": "released"
+    "status": "legacy-leaf"
   },
   "nbdkit": {
     "build_deps": [
@@ -37067,7 +37486,8 @@
       "python3"
     ],
     "deps": [
-      "python2"
+      "python2",
+      "python3"
     ],
     "links": {
       "bug": [
@@ -37077,6 +37497,15 @@
       ]
     },
     "rpms": {
+      "nbdkit-python-plugin-common-1.7.4-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "nbdkit-python2-plugin-1.7.4-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -37100,7 +37529,10 @@
         }
       }
     },
-    "status": "legacy-leaf"
+    "status": "legacy-leaf",
+    "unversioned_requirers": [
+      "nbdkit"
+    ]
   },
   "needrestart": {
     "build_deps": [
@@ -37211,6 +37643,17 @@
         "py_deps": {
           "libpython2.7.so.1.0()(64bit)": 2
         }
+      },
+      "python2-nemo-devel-3.8.0-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [
+            "font-manager"
+          ],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "idle",
@@ -39922,6 +40365,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-numpy-doc-1:1.15.1-1.fc30": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-numpy-f2py-1:1.15.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -39949,6 +40401,15 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-numpy-doc-1:1.15.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "python3-numpy-f2py-1:1.15.1-1.fc30": {
         "almost_leaf": false,
@@ -41229,6 +41690,41 @@
     },
     "status": "released"
   },
+  "openmpi": {
+    "build_deps": [
+      "python2",
+      "python3"
+    ],
+    "deps": [],
+    "links": {
+      "bug": [
+        "https://bugzilla.redhat.com/show_bug.cgi?id=1391157",
+        "CLOSED RAWHIDE",
+        "2016-11-02 18:54:18"
+      ]
+    },
+    "rpms": {
+      "python2-openmpi-2.1.5-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python3-openmpi-2.1.5-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      }
+    },
+    "status": "released"
+  },
   "openms": {
     "build_deps": [
       "Cython",
@@ -41501,6 +41997,7 @@
   },
   "openvdb": {
     "build_deps": [
+      "boost",
       "epydoc",
       "numpy",
       "python3"
@@ -43113,7 +43610,9 @@
     "build_deps": [
       "python3"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "rpms": {
       "perl-Inline-Python-0.56-6.fc29": {
         "almost_leaf": false,
@@ -43161,6 +43660,7 @@
   "pesign": {
     "build_deps": [
       "git",
+      "python-rpm-macros",
       "python3"
     ],
     "deps": [],
@@ -43473,7 +43973,8 @@
       "python3"
     ],
     "deps": [
-      "dbus-python"
+      "dbus-python",
+      "python3"
     ],
     "rpms": {
       "finch-2.13.0-7.fc30": {
@@ -44167,6 +44668,7 @@
   "plplot": {
     "build_deps": [
       "numpy",
+      "python-qt5",
       "python3"
     ],
     "deps": [
@@ -44630,7 +45132,8 @@
       "systemtap"
     ],
     "deps": [
-      "python2"
+      "python2",
+      "python3"
     ],
     "links": {
       "bug": [
@@ -44781,6 +45284,7 @@
   },
   "prepaid-manager-applet": {
     "build_deps": [
+      "dbus-python",
       "gnome-doc-utils"
     ],
     "deps": [
@@ -45235,6 +45739,7 @@
   },
   "pulp": {
     "build_deps": [
+      "python-rpm-macros",
       "python-setuptools",
       "python-sphinx",
       "python2"
@@ -45461,6 +45966,7 @@
   },
   "pulp-docker": {
     "build_deps": [
+      "python-rpm-macros",
       "python-setuptools",
       "python-sphinx",
       "python2"
@@ -45675,6 +46181,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "pulp-python-doc-2.0.2-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "pulp-python-plugins-2.0.2-1.fc29": {
         "almost_leaf": true,
         "is_misnamed": true,
@@ -45703,6 +46218,7 @@
   },
   "pulp-rpm": {
     "build_deps": [
+      "python-rpm-macros",
       "python-setuptools",
       "python-sphinx",
       "python2"
@@ -47010,6 +47526,7 @@
   },
   "pyexiv2": {
     "build_deps": [
+      "boost",
       "python2",
       "pytz",
       "scons"
@@ -47899,6 +48416,7 @@
   },
   "pykde4": {
     "build_deps": [
+      "PyQt4",
       "python2",
       "python3",
       "sip"
@@ -47942,6 +48460,24 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-pykde4-devel-4.14.3-28.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python3-pykde4-examples-4.14.3-28.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -47965,6 +48501,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-pyke-examples-1.1.1-28.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -48501,6 +49046,7 @@
   },
   "pyosmium": {
     "build_deps": [
+      "boost",
       "python-mock",
       "python-nose",
       "python-sphinx",
@@ -48892,6 +49438,7 @@
   },
   "pyqtrailer": {
     "build_deps": [
+      "PyQt4",
       "python-dateutil",
       "python-setuptools",
       "python2",
@@ -49282,6 +49829,7 @@
   },
   "pyside-tools": {
     "build_deps": [
+      "python-pyside",
       "python2"
     ],
     "deps": [
@@ -49675,6 +50223,15 @@
       "python3"
     ],
     "rpms": {
+      "python-APScheduler-doc-3.5.3-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-APScheduler-3.5.3-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -49715,6 +50272,15 @@
       "python3"
     ],
     "rpms": {
+      "python-apptools-doc-4.4.0-12.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-apptools-4.4.0-12.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -49788,6 +50354,7 @@
   "python-BTrees": {
     "build_deps": [
       "python-nose",
+      "python-persistent",
       "python-repoze-sphinx-autointerface",
       "python-setuptools",
       "python-sphinx",
@@ -49874,6 +50441,15 @@
       "scipy"
     ],
     "rpms": {
+      "python-Bottleneck-doc-1.2.1-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-Bottleneck-1.2.1-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -49978,6 +50554,15 @@
       "python3"
     ],
     "rpms": {
+      "python-CommonMark-doc-0.8.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-CommonMark-0.8.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -50005,6 +50590,15 @@
       "python3"
     ],
     "rpms": {
+      "python-ECPy-doc-0.8.2-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-ECPy-0.8.2-5.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -50284,6 +50878,15 @@
       "scipy"
     ],
     "rpms": {
+      "python-MDAnalysis-doc-0.18.0-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-MDAnalysis-0.18.0-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -50563,6 +51166,15 @@
       "python3"
     ],
     "rpms": {
+      "python-PyMuPDF-doc-1.13.20-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-PyMuPDF-1.13.20-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -50638,6 +51250,15 @@
       "python3"
     ],
     "rpms": {
+      "python-PyPDF2-doc-1.26.0-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-PyPDF2-1.26.0-6.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -50973,6 +51594,15 @@
       ]
     },
     "rpms": {
+      "python-SecretStorage-doc-2.3.1-10.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-SecretStorage-2.3.1-10.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -52625,6 +53255,15 @@
       "python3"
     ],
     "rpms": {
+      "python-ZODB-doc-5.4.0-4.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-ZODB-5.4.0-4.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -52813,6 +53452,15 @@
       "python3"
     ],
     "rpms": {
+      "python-abimap-doc-0.3.1-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-abimap-0.3.1-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -52861,6 +53509,15 @@
       "pytz"
     ],
     "rpms": {
+      "python-acme-doc-0.27.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-acme-0.27.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -53206,6 +53863,15 @@
       "python3"
     ],
     "rpms": {
+      "python-afl-bin-0.7-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-afl-0.7-3.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -53231,7 +53897,10 @@
         }
       }
     },
-    "status": "legacy-leaf"
+    "status": "legacy-leaf",
+    "unversioned_requirers": [
+      "python-afl"
+    ]
   },
   "python-agate": {
     "build_deps": [
@@ -53265,6 +53934,15 @@
       "python3"
     ],
     "rpms": {
+      "python-agate-doc-1.6.1-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-agate-1.6.1-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -53308,6 +53986,15 @@
       "python3"
     ],
     "rpms": {
+      "python-agate-dbf-doc-0.2.0-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-agate-dbf-0.2.0-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -53353,6 +54040,15 @@
       "python3"
     ],
     "rpms": {
+      "python-agate-excel-doc-0.2.2-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-agate-excel-0.2.2-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -53395,6 +54091,15 @@
       "python3"
     ],
     "rpms": {
+      "python-agate-sql-doc-0.5.3-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-agate-sql-0.5.3-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -53594,6 +54299,7 @@
       "python-atpublic",
       "python-flufl-testing",
       "python-nose2",
+      "python-rpm-macros",
       "python-setuptools",
       "python3"
     ],
@@ -53906,6 +54612,15 @@
       "python3"
     ],
     "rpms": {
+      "python-amqp-doc-2.3.2-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-amqp-2.3.2-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -53957,6 +54672,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-animatplot-doc-0.2.2-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -54196,6 +54920,15 @@
       "python3"
     ],
     "rpms": {
+      "python-ansicolor-doc-0.2.4-9.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-ansicolor-0.2.4-9.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -54254,6 +54987,15 @@
       "python3"
     ],
     "rpms": {
+      "python-anyconfig-doc-0.9.7-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-anyconfig-0.9.7-1.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -54520,6 +55262,15 @@
       ]
     },
     "rpms": {
+      "python-aodhclient-doc-0.7.0-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-aodhclient-0.7.0-7.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -55191,6 +55942,15 @@
       "scipy"
     ],
     "rpms": {
+      "python-astroML-doc-0.3-22.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-astroML-0.3-22.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -55317,6 +56077,15 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-astropy-doc-3.0.4-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -55613,6 +56382,7 @@
     "build_deps": [
       "python-flufl-testing",
       "python-nose2",
+      "python-rpm-macros",
       "python-setuptools",
       "python3"
     ],
@@ -55862,6 +56632,15 @@
       "python3"
     ],
     "rpms": {
+      "python-automaton-doc-1.14.0-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-automaton-1.14.0-3.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -55957,6 +56736,15 @@
       "python2"
     ],
     "rpms": {
+      "python-avocado-examples-52.1-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-avocado-52.1-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -56059,6 +56847,15 @@
       "python3"
     ],
     "rpms": {
+      "python-azure-sdk-doc-4.0.0-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-azure-sdk-4.0.0-2.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -56109,6 +56906,15 @@
       "python3"
     ],
     "rpms": {
+      "python-azure-storage-doc-1.2.0-0.3.rc1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-azure-storage-1.2.0-0.3.rc1.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -56145,6 +56951,15 @@
       "python3"
     ],
     "rpms": {
+      "python-babelfish-doc-0.5.5-11.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-babelfish-0.5.5-11.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -56522,6 +57337,15 @@
       ]
     },
     "rpms": {
+      "python-barbicanclient-doc-4.6.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-barbicanclient-4.6.0-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -56558,11 +57382,21 @@
       "python3"
     ],
     "deps": [
+      "python-basemap-data",
       "python-matplotlib",
       "python2",
       "python3"
     ],
     "rpms": {
+      "python-basemap-examples-1.0.7-27.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-basemap-1.0.7-27.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -56589,6 +57423,27 @@
       }
     },
     "status": "released"
+  },
+  "python-basemap-data": {
+    "build_deps": [
+      "python2"
+    ],
+    "deps": [],
+    "rpms": {
+      "python-basemap-data-1.0.7-9.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      }
+    },
+    "status": "released",
+    "unversioned_requirers": [
+      "python-basemap"
+    ]
   },
   "python-bash8": {
     "build_deps": [
@@ -56659,6 +57514,15 @@
       ]
     },
     "rpms": {
+      "python-bashate-doc-0.5.1-9.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-bashate-0.5.1-9.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -56921,6 +57785,15 @@
       "python3"
     ],
     "rpms": {
+      "python-behave-doc-1.2.6-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-behave-1.2.6-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -57081,6 +57954,15 @@
       "python3"
     ],
     "rpms": {
+      "python-binaryornot-docs-0.4.3-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-binaryornot-0.4.3-2.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -57203,6 +58085,15 @@
       "python3"
     ],
     "rpms": {
+      "python-biopython-doc-1.72-3.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-biopython-1.72-3.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -57437,6 +58328,15 @@
       "python3"
     ],
     "rpms": {
+      "python-bitstruct-doc-3.7.0-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-bitstruct-3.7.0-4.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -58309,6 +59209,15 @@
       "python3"
     ],
     "rpms": {
+      "python-breathe-doc-4.7.3-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-breathe-4.7.3-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -58352,6 +59261,15 @@
       "python3"
     ],
     "rpms": {
+      "python-btchip-common-0.1.26-4.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-btchip-0.1.26-4.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -58746,7 +59664,9 @@
     "build_deps": [
       "python3"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "links": {
       "bug": [
         "https://bugzilla.redhat.com/show_bug.cgi?id=1560724",
@@ -58755,6 +59675,15 @@
       ]
     },
     "rpms": {
+      "python-caja-devel-1:1.20.1-3.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-caja-1:1.20.1-3.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -58952,6 +59881,15 @@
       "python3"
     ],
     "rpms": {
+      "python-cartopy-common-0.16.0-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-cartopy-0.16.0-6.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -58977,7 +59915,10 @@
         }
       }
     },
-    "status": "legacy-leaf"
+    "status": "legacy-leaf",
+    "unversioned_requirers": [
+      "python-cartopy"
+    ]
   },
   "python-case": {
     "build_deps": [
@@ -59052,6 +59993,15 @@
       ]
     },
     "rpms": {
+      "python-cassandra-driver-doc-3.14.0-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-cassandra-driver-3.14.0-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -59104,6 +60054,15 @@
       "python3"
     ],
     "rpms": {
+      "python-castellan-doc-0.5.0-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-castellan-0.5.0-5.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -59285,6 +60244,15 @@
       "python3"
     ],
     "rpms": {
+      "python-catkin_tools-doc-0.4.4-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-catkin_tools-0.4.4-7.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -59544,6 +60512,7 @@
     "build_deps": [
       "python-billiard",
       "python-kombu",
+      "python-rpm-macros",
       "python-setuptools",
       "python-sphinx",
       "python-sqlalchemy",
@@ -59562,6 +60531,15 @@
       "pytz"
     ],
     "rpms": {
+      "python-celery-doc-4.2.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-celery-4.2.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -59711,6 +60689,15 @@
       "python3"
     ],
     "rpms": {
+      "python-certbot-dns-cloudflare-doc-0.27.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-certbot-dns-cloudflare-0.27.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -59757,6 +60744,15 @@
       "python3"
     ],
     "rpms": {
+      "python-certbot-dns-cloudxns-doc-0.27.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-certbot-dns-cloudxns-0.27.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -59852,6 +60848,15 @@
       "python3"
     ],
     "rpms": {
+      "python-certbot-dns-dnsimple-doc-0.27.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-certbot-dns-dnsimple-0.27.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -59898,6 +60903,15 @@
       "python3"
     ],
     "rpms": {
+      "python-certbot-dns-dnsmadeeasy-doc-0.27.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-certbot-dns-dnsmadeeasy-0.27.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -59946,6 +60960,15 @@
       "python3"
     ],
     "rpms": {
+      "python-certbot-dns-gehirn-doc-0.27.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-certbot-dns-gehirn-0.27.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -60044,6 +61067,15 @@
       "python3"
     ],
     "rpms": {
+      "python-certbot-dns-linode-doc-0.27.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-certbot-dns-linode-0.27.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -60091,6 +61123,15 @@
       "python3"
     ],
     "rpms": {
+      "python-certbot-dns-luadns-doc-0.27.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-certbot-dns-luadns-0.27.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -60137,6 +61178,15 @@
       "python3"
     ],
     "rpms": {
+      "python-certbot-dns-nsone-doc-0.27.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-certbot-dns-nsone-0.27.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -60185,6 +61235,15 @@
       "python3"
     ],
     "rpms": {
+      "python-certbot-dns-ovh-doc-0.27.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-certbot-dns-ovh-0.27.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -60325,6 +61384,15 @@
       "python3"
     ],
     "rpms": {
+      "python-certbot-dns-sakuracloud-doc-0.27.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-certbot-dns-sakuracloud-0.27.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -60443,6 +61511,15 @@
       "python3"
     ],
     "rpms": {
+      "python-cffi-doc-1.11.5-6.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-cffi-1.11.5-6.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -60771,6 +61848,15 @@
       ]
     },
     "rpms": {
+      "python-cinderclient-doc-3.5.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-cinderclient-3.5.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -60953,6 +62039,15 @@
     },
     "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
     "rpms": {
+      "python-cliapp-doc-1.20160724-8.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-cliapp-1.20160724-8.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -61341,6 +62436,15 @@
       "python3"
     ],
     "rpms": {
+      "python-clint-doc-0.5.1-10.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-clint-0.5.1-10.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -61522,6 +62626,15 @@
       "python2"
     ],
     "rpms": {
+      "python-cloudservers-doc-1.2-17.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-cloudservers-1.2-17.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -61690,6 +62803,15 @@
       ]
     },
     "rpms": {
+      "python-cmdln-doc-2.0.0-9.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-cmdln-2.0.0-9.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -61878,6 +63000,15 @@
       "python3"
     ],
     "rpms": {
+      "python-collectd_systemd-selinux-0.0.1-0.8.20180604gitbe9c647.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-collectd_systemd-0.0.1-0.8.20180604gitbe9c647.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -61901,7 +63032,10 @@
         }
       }
     },
-    "status": "legacy-leaf"
+    "status": "legacy-leaf",
+    "unversioned_requirers": [
+      "python-collectd_systemd"
+    ]
   },
   "python-colorama": {
     "build_deps": [
@@ -62011,6 +63145,15 @@
       "python3"
     ],
     "rpms": {
+      "python-colorspacious-doc-1.1.2-4.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-colorspacious-1.1.2-4.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -62334,6 +63477,15 @@
       ]
     },
     "rpms": {
+      "python-congressclient-doc-1.5.0-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-congressclient-1.5.0-7.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -62556,6 +63708,15 @@
       "python3"
     ],
     "rpms": {
+      "python-cookiecutter-doc-1.6.0-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-cookiecutter-1.6.0-5.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -62644,6 +63805,15 @@
       "python3"
     ],
     "rpms": {
+      "python-copr-doc-1.90-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-copr-1.90-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -62799,6 +63969,15 @@
       ]
     },
     "rpms": {
+      "python-cotyledon-doc-1.6.7-8.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-cotyledon-1.6.7-8.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -62863,6 +64042,15 @@
       "python3"
     ],
     "rpms": {
+      "python-couchbase-doc-2.5.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-couchbase-2.5.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -62918,6 +64106,7 @@
   },
   "python-cov-core": {
     "build_deps": [
+      "python-rpm-macros",
       "python-setuptools",
       "python2",
       "python3"
@@ -63598,6 +64787,15 @@
       ]
     },
     "rpms": {
+      "python-cssutils-doc-1.0.1-11.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-cssutils-1.0.1-11.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -63632,6 +64830,7 @@
       "python-agate-sql",
       "python-nose",
       "python-six",
+      "python-sphinx",
       "python-sphinx_rtd_theme",
       "python-unittest2",
       "python2",
@@ -63648,6 +64847,15 @@
       "python3"
     ],
     "rpms": {
+      "python-csvkit-doc-1.0.3-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-csvkit-1.0.3-3.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -63734,6 +64942,15 @@
       ]
     },
     "rpms": {
+      "python-cups-doc-1.9.74-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-cups-1.9.74-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -63817,6 +65034,15 @@
       "python3"
     ],
     "rpms": {
+      "python-cursive-doc-0.1.2-7.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-cursive-0.1.2-7.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -63902,9 +65128,19 @@
       "python3"
     ],
     "deps": [
+      "python-matplotlib",
       "python3"
     ],
     "rpms": {
+      "python-cvxopt-examples-1.2.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-cvxopt-1.2.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -63974,6 +65210,15 @@
       "python3"
     ],
     "rpms": {
+      "python-cypari2-doc-1.2.1-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-cypari2-1.2.1-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -64037,6 +65282,15 @@
       "python3"
     ],
     "rpms": {
+      "python-cysignals-doc-1.7.2-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-cysignals-1.7.2-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -64272,6 +65526,15 @@
       "python3"
     ],
     "rpms": {
+      "python-daiquiri-doc-1.5.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-daiquiri-1.5.0-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -64414,6 +65677,15 @@
       "python3"
     ],
     "rpms": {
+      "python-dateutil-doc-1:2.7.3-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-dateutil-1:2.7.3-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -64502,6 +65774,15 @@
       "python3"
     ],
     "rpms": {
+      "python-dbfread-doc-2.0.7-7.git300b2d7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-dbfread-2.0.7-7.git300b2d7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -64707,6 +65988,15 @@
       "python3"
     ],
     "rpms": {
+      "python-deap-doc-1.0.1-9.20160624git232ed17.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-deap-1.0.1-9.20160624git232ed17.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -64821,6 +66111,15 @@
       "python3"
     ],
     "rpms": {
+      "python-debtcollector-doc-1.11.0-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-debtcollector-1.11.0-6.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -65198,6 +66497,15 @@
       ]
     },
     "rpms": {
+      "python-designateclient-doc-2.9.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-designateclient-2.9.0-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -65314,6 +66622,15 @@
       "python3"
     ],
     "rpms": {
+      "python-dict-sorted-doc-1.0.0-8.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-dict-sorted-1.0.0-8.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -65708,6 +67025,15 @@
       "pytz"
     ],
     "rpms": {
+      "python-django-bash-completion-2.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-django-2.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -65719,6 +67045,15 @@
           "/usr/bin/python3": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-django-doc-2.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -65769,6 +67104,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-django-angular-doc-2.0.3-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -65947,6 +67291,15 @@
       "python3"
     ],
     "rpms": {
+      "python-django-classy-tags-doc-0.7.2-10.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-django-classy-tags-0.7.2-10.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -66253,6 +67606,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-django-formtools-doc-2.1-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -66276,6 +67638,15 @@
       ]
     },
     "rpms": {
+      "python-django-haystack-docs-2.5.0-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-django-haystack-2.5.0-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -66669,6 +68040,15 @@
       ]
     },
     "rpms": {
+      "python-django-registration-doc-2.1.2-8.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-django-registration-2.1.2-8.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -66965,6 +68345,15 @@
       ]
     },
     "rpms": {
+      "python-django-tastypie-doc-0.13.3-11.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-django-tastypie-0.13.3-11.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -67195,11 +68584,13 @@
     ],
     "deps": [
       "pyOpenSSL",
+      "pytest",
       "python-backports-ssl_match_hostname",
       "python-cryptography",
       "python-docker-pycreds",
       "python-idna",
       "python-ipaddress",
+      "python-mock",
       "python-requests",
       "python-six",
       "python-websocket-client",
@@ -67218,6 +68609,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-docker-tests-3.5.0-1.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-docker-3.5.0-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -67230,7 +68630,7 @@
         }
       }
     },
-    "status": "released"
+    "status": "idle"
   },
   "python-docker-pycreds": {
     "build_deps": [
@@ -67440,7 +68840,6 @@
             "cifs-utils",
             "klavaro",
             "midori",
-            "python2-docs",
             "varnish-modules",
             "xss-lock"
           ],
@@ -67461,7 +68860,6 @@
             "dbus-broker",
             "fuse-sshfs",
             "hugo",
-            "python3-docs",
             "rsyslog",
             "vmod-uuid"
           ],
@@ -67585,6 +68983,15 @@
           "/usr/bin/python3": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-doit-doc-0.31.1-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -68133,6 +69540,24 @@
       "python2"
     ],
     "rpms": {
+      "python-egenix-mx-base-devel-3.2.9-8.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-egenix-mx-base-doc-3.2.9-8.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-egenix-mx-base-3.2.9-8.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -68466,6 +69891,15 @@
       "python3"
     ],
     "rpms": {
+      "python-entrypoints-doc-0.2.3-9.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-entrypoints-0.2.3-9.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -68565,6 +69999,15 @@
       "python3"
     ],
     "rpms": {
+      "python-envisage-doc-4.6.0-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-envisage-4.6.0-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -68600,6 +70043,15 @@
       "python3"
     ],
     "rpms": {
+      "python-enzyme-doc-0.4.1-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-enzyme-0.4.1-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -68731,6 +70183,15 @@
       "python3"
     ],
     "rpms": {
+      "python-epub-doc-0.5.2-14.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-epub-0.5.2-14.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -68937,6 +70398,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-eventlet-doc-0.23.0-2.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-eventlet-0.23.0-2.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -68947,6 +70417,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-eventlet-doc-0.23.0-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released",
@@ -69333,6 +70812,15 @@
       "python3"
     ],
     "rpms": {
+      "python-f5-sdk-doc-3.0.20-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-f5-sdk-3.0.20-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -69461,6 +70949,15 @@
       "python3"
     ],
     "rpms": {
+      "python-factory-boy-doc-2.11.1-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-factory-boy-2.11.1-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -69499,6 +70996,15 @@
       "python3"
     ],
     "rpms": {
+      "python-faker-doc-0.9.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-faker-0.9.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -69592,6 +71098,15 @@
       "python3"
     ],
     "rpms": {
+      "python-fastavro-doc-0.19.8-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-fastavro-0.19.8-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -69784,6 +71299,15 @@
       "python3"
     ],
     "rpms": {
+      "python-fdb-doc-1.8-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-fdb-1.8-4.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -70123,6 +71647,15 @@
       "python3"
     ],
     "rpms": {
+      "python-feedparser-doc-5.2.1-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-feedparser-5.2.1-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -70200,6 +71733,15 @@
       "python3"
     ],
     "rpms": {
+      "python-filelock-doc-3.0.8-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-filelock-3.0.8-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -70615,6 +72157,15 @@
       ]
     },
     "rpms": {
+      "python-flask-doc-1:1.0.2-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-flask-1:1.0.2-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -70754,6 +72305,15 @@
       "python3"
     ],
     "rpms": {
+      "python-flask-autoindex-docs-0.6-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-flask-autoindex-0.6-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -70933,6 +72493,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-flask-cache-doc-0.13.1-14.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -71114,6 +72683,15 @@
       "python3"
     ],
     "rpms": {
+      "python-flask-httpauth-doc-3.2.3-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-flask-httpauth-3.2.3-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -71708,6 +73286,15 @@
       "python3"
     ],
     "rpms": {
+      "python-flask-security-doc-3.0.0-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-flask-security-3.0.0-3.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -71748,6 +73335,15 @@
       "python3"
     ],
     "rpms": {
+      "python-flask-silk-docs-0.2-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-flask-silk-0.2-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -72178,6 +73774,7 @@
     "build_deps": [
       "python-atpublic",
       "python-nose2",
+      "python-rpm-macros",
       "python-setuptools",
       "python-zope-interface",
       "python3"
@@ -72206,6 +73803,7 @@
   "python-flufl-i18n": {
     "build_deps": [
       "python-atpublic",
+      "python-rpm-macros",
       "python-setuptools",
       "python3"
     ],
@@ -72232,6 +73830,7 @@
   "python-flufl-lock": {
     "build_deps": [
       "python-atpublic",
+      "python-rpm-macros",
       "python-setuptools",
       "python3"
     ],
@@ -72257,6 +73856,7 @@
   },
   "python-flufl-testing": {
     "build_deps": [
+      "python-rpm-macros",
       "python-setuptools",
       "python3"
     ],
@@ -72642,6 +74242,15 @@
       "python3"
     ],
     "rpms": {
+      "python-formencode-langpacks-1.3.1-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-formencode-1.3.1-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -72667,6 +74276,7 @@
     },
     "status": "released",
     "unversioned_requirers": [
+      "python-formencode",
       "python-pylons"
     ]
   },
@@ -73005,6 +74615,15 @@
       "python3"
     ],
     "rpms": {
+      "python-funcsigs-doc-1.0.2-11.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-funcsigs-1.0.2-11.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -73160,6 +74779,15 @@
       "python3"
     ],
     "rpms": {
+      "python-futurist-doc-1.7.0-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-futurist-1.7.0-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -73307,6 +74935,15 @@
       "python3"
     ],
     "rpms": {
+      "python-gabbi-doc-1.42.1-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-gabbi-1.42.1-4.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -73400,6 +75037,7 @@
   },
   "python-gattlib": {
     "build_deps": [
+      "boost",
       "glib2",
       "python-setuptools",
       "python2",
@@ -73599,6 +75237,7 @@
   "python-gencpp": {
     "build_deps": [
       "catkin",
+      "python-genmsg",
       "python2"
     ],
     "deps": [
@@ -73614,6 +75253,15 @@
     },
     "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
     "rpms": {
+      "python-gencpp-devel-0.3.4-14.20130623git403d067.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-gencpp-0.3.4-14.20130623git403d067.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -73632,6 +75280,7 @@
   "python-genlisp": {
     "build_deps": [
       "catkin",
+      "python-genmsg",
       "python2"
     ],
     "deps": [
@@ -73647,6 +75296,15 @@
     },
     "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
     "rpms": {
+      "python-genlisp-devel-0.3.3-14.20130623git8790a17.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-genlisp-0.3.3-14.20130623git8790a17.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -73681,6 +75339,15 @@
     },
     "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
     "rpms": {
+      "python-genmsg-devel-0.3.10-16.20130617git95ca00d.fc28": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-genmsg-0.3.10-16.20130617git95ca00d.fc28": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -73693,12 +75360,18 @@
         }
       }
     },
-    "status": "mispackaged"
+    "status": "mispackaged",
+    "unversioned_requirers": [
+      "python-gencpp",
+      "python-genlisp",
+      "python-genpy"
+    ]
   },
   "python-genpy": {
     "build_deps": [
       "catkin",
       "python-catkin-sphinx",
+      "python-genmsg",
       "python-nose",
       "python2"
     ],
@@ -73707,6 +75380,15 @@
       "python2"
     ],
     "rpms": {
+      "python-genpy-devel-0.3.7-16.20130623giteddf66e.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-genpy-0.3.7-16.20130623giteddf66e.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -73784,6 +75466,15 @@
       "scipy"
     ],
     "rpms": {
+      "python-gensim-doc-0.10.0-15.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-gensim-addons-0.10.0-15.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -73897,6 +75588,15 @@
       "python3"
     ],
     "rpms": {
+      "python-geoip2-doc-2.9.0-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-geoip2-2.9.0-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -74147,6 +75847,7 @@
   },
   "python-gevent": {
     "build_deps": [
+      "python-greenlet",
       "python2",
       "python3"
     ],
@@ -74284,6 +75985,15 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-giacpy-devel-0.6.7-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -74409,6 +76119,15 @@
       "python3"
     ],
     "rpms": {
+      "python-gitlab-doc-1.3.0-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-gitlab-1.3.0-5.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -74512,6 +76231,15 @@
       "python3"
     ],
     "rpms": {
+      "python-glanceclient-doc-1:2.10.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-glanceclient-1:2.10.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -74757,6 +76485,15 @@
       ]
     },
     "rpms": {
+      "python-gnocchiclient-doc-7.0.4-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-gnocchiclient-7.0.4-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -75242,6 +76979,15 @@
       ]
     },
     "rpms": {
+      "python-grafyaml-doc-0.0.5-9.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-grafyaml-0.0.5-9.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -75395,6 +77141,15 @@
       "python3"
     ],
     "rpms": {
+      "python-graphviz-doc-1:0.8.3-4.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-graphviz-1:0.8.3-4.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -75443,6 +77198,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-greenlet-devel-0.4.14-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-greenlet-0.4.14-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -75454,6 +77218,15 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-greenlet-devel-0.4.14-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released",
@@ -75515,6 +77288,15 @@
       "python3"
     ],
     "rpms": {
+      "python-gsd-doc-1.5.1-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-gsd-1.5.1-3.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -75672,6 +77454,15 @@
       "python3"
     ],
     "rpms": {
+      "python-guessit-doc-2.1.4-8.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-guessit-2.1.4-8.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -75740,6 +77531,15 @@
       "python3"
     ],
     "rpms": {
+      "python-gunicorn-doc-19.9.0-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-gunicorn-19.9.0-2.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -75830,6 +77630,15 @@
       "python3"
     ],
     "rpms": {
+      "python-h2-doc-3.0.1-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-h2-3.0.1-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -76025,6 +77834,15 @@
       "python3"
     ],
     "rpms": {
+      "python-hardware-doc-0.18-12.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-hardware-0.18-12.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -76086,6 +77904,15 @@
       "python3"
     ],
     "rpms": {
+      "python-hdfs-doc-2.1.0-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-hdfs-2.1.0-6.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -76216,6 +78043,15 @@
       ]
     },
     "rpms": {
+      "python-heatclient-doc-1.14.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-heatclient-1.14.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -76453,6 +78289,15 @@
       "python3"
     ],
     "rpms": {
+      "python-hl7-doc-0.3.3-11.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-hl7-0.3.3-11.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -76720,6 +78565,15 @@
       "python3"
     ],
     "rpms": {
+      "python-htmlmin-doc-0.1.12-5.git220b1d1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-htmlmin-0.1.12-5.git220b1d1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -77322,6 +79176,15 @@
       "python3"
     ],
     "rpms": {
+      "python-hyperlink-doc-18.0.0-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-hyperlink-18.0.0-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -77649,6 +79512,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-igraph-devel-0.7.1.post6-12.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-igraph-0.7.1.post6-12.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -77661,6 +79533,15 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-igraph-devel-0.7.1.post6-12.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "legacy-leaf",
@@ -78529,6 +80410,7 @@
     "deps": [
       "ipython",
       "python-jupyter-client",
+      "python-jupyter-core",
       "python-tornado",
       "python-traitlets",
       "python2",
@@ -78536,6 +80418,15 @@
       "python3"
     ],
     "rpms": {
+      "python-ipykernel-doc-4.8.2-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-ipykernel-4.8.2-4.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -78592,6 +80483,7 @@
       "python-ipykernel",
       "python-ipython_genutils",
       "python-jupyter-client",
+      "python-jupyter-core",
       "python-mock",
       "python-nose",
       "python-tornado",
@@ -78602,6 +80494,15 @@
       "python3"
     ],
     "rpms": {
+      "python-ipyparallel-doc-6.2.2-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-ipyparallel-6.2.2-2.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -78887,6 +80788,7 @@
   },
   "python-iso8601": {
     "build_deps": [
+      "python-rpm-macros",
       "python-setuptools",
       "python2",
       "python3"
@@ -79060,6 +80962,15 @@
       "python3"
     ],
     "rpms": {
+      "python-ivi-doc-0.14.9-14.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-ivi-0.14.9-14.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -79536,6 +81447,15 @@
       "python3"
     ],
     "rpms": {
+      "python-jep-javadoc-3.8.0-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-jep-3.8.0-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -79847,6 +81767,15 @@
       "python3"
     ],
     "rpms": {
+      "python-jnius-doc-1.1.1-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pyjnius-1.1.1-6.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -80210,6 +82139,15 @@
       "python3"
     ],
     "rpms": {
+      "python-jsonpath-rw-ext-doc-1.0.0-9.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-jsonpath-rw-ext-1.0.0-9.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -80526,6 +82464,15 @@
       "python3"
     ],
     "rpms": {
+      "python-jupyter-client-doc-5.2.3-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-jupyter-client-5.2.3-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -80558,7 +82505,8 @@
       "python-sphinx",
       "python-sphinxcontrib-github-alt",
       "python2",
-      "python3"
+      "python3",
+      "python3-docs"
     ],
     "deps": [
       "python-setuptools",
@@ -80567,6 +82515,24 @@
       "python3"
     ],
     "rpms": {
+      "python-jupyter-core-doc-4.4.0-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-jupyter-filesystem-4.4.0-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-jupyter-core-4.4.0-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -80591,7 +82557,12 @@
         }
       }
     },
-    "status": "released"
+    "status": "released",
+    "unversioned_requirers": [
+      "python-ipykernel",
+      "python-metakernel",
+      "root"
+    ]
   },
   "python-jupyter-kernel-test": {
     "build_deps": [
@@ -80838,6 +82809,15 @@
       "python3"
     ],
     "rpms": {
+      "python-k8sclient-doc-0.3.0-8.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-k8sclient-0.3.0-8.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -80981,6 +82961,15 @@
       "python3"
     ],
     "rpms": {
+      "python-kazoo-doc-2.5.0-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-kazoo-2.5.0-2.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -81261,6 +83250,15 @@
       "python3"
     ],
     "rpms": {
+      "python-keystoneclient-doc-1:3.15.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-keystoneclient-1:3.15.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -81394,6 +83392,15 @@
       ]
     },
     "rpms": {
+      "python-keystonemiddleware-doc-4.21.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-keystonemiddleware-4.21.0-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -81457,6 +83464,15 @@
       "python3"
     ],
     "rpms": {
+      "python-kitchen-doc-1.2.5-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-kitchen-1.2.5-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -81480,6 +83496,15 @@
           "python3": 3,
           "python3 = 3.7.0-10.fc30": 3
         }
+      },
+      "python3-kitchen-doc-1.2.5-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -81508,6 +83533,24 @@
           "pygtk2 = 2.24.0-23.fc29": 2,
           "python(abi) = 2.7": 2
         }
+      },
+      "python2-kiwi-gtk-docs-1.11.1-3.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python2-kiwi-gtk-glade-1.11.1-3.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "idle"
@@ -81914,6 +83957,15 @@
       "python2"
     ],
     "rpms": {
+      "python-larch-doc-1.20151025-9.fc28": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-larch-1.20151025-9.fc28": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -82179,6 +84231,15 @@
       "python3"
     ],
     "rpms": {
+      "python-lazyarray-docs-0.2.8-12.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-lazyarray-0.2.8-12.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -82200,6 +84261,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-lazyarray-docs-0.2.8-12.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "legacy-leaf"
@@ -82351,6 +84421,15 @@
       "python2"
     ],
     "rpms": {
+      "python-ldaptor-doc-16.0.1-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python-ldaptor-tools-16.0.1-3.fc29": {
         "almost_leaf": true,
         "is_misnamed": true,
@@ -82401,6 +84480,15 @@
       "python3"
     ],
     "rpms": {
+      "python-leather-doc-0.3.3-7.gite85dd30.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-leather-0.3.3-7.gite85dd30.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -82797,6 +84885,15 @@
       "scipy"
     ],
     "rpms": {
+      "python-librosa-doc-0.5.1-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-librosa-0.5.1-6.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -83165,6 +85262,15 @@
       "python3"
     ],
     "rpms": {
+      "python-livereload-docs-2.5.2-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-livereload-2.5.2-2.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -83773,6 +85879,15 @@
       "python3"
     ],
     "rpms": {
+      "python-magnumclient-doc-2.9.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-magnumclient-2.9.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -83883,6 +85998,15 @@
       "python3"
     ],
     "rpms": {
+      "python-mako-doc-1.0.6-11.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-mako-1.0.6-11.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -83988,6 +86112,15 @@
       ]
     },
     "rpms": {
+      "python-manilaclient-doc-1.21.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-manilaclient-1.21.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -84057,6 +86190,7 @@
   },
   "python-mapnik": {
     "build_deps": [
+      "boost",
       "pycairo",
       "python-PyPDF2",
       "python-nose",
@@ -84417,6 +86551,15 @@
       "python3"
     ],
     "rpms": {
+      "python-marshmallow-doc-2.11.1-8.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-marshmallow-2.11.1-8.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -84533,6 +86676,7 @@
   },
   "python-matplotlib": {
     "build_deps": [
+      "PyQt4",
       "numpy",
       "pycairo",
       "pygobject3",
@@ -84559,6 +86703,7 @@
       "python-cycler",
       "python-dateutil",
       "python-kiwisolver",
+      "python-qt5",
       "python-wxpython4",
       "python3"
     ],
@@ -84576,6 +86721,33 @@
           "python3-cairo": 3,
           "python3-cairo = 1.17.1-2.fc29": 3
         }
+      },
+      "python3-matplotlib-data-3.0.0-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python3-matplotlib-data-fonts-3.0.0-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python3-matplotlib-doc-3.0.0-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "python3-matplotlib-gtk3-3.0.0-2.fc30": {
         "almost_leaf": false,
@@ -84598,6 +86770,24 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-matplotlib-qt5-3.0.0-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python3-matplotlib-test-data-3.0.0-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "python3-matplotlib-tk-3.0.0-2.fc30": {
         "almost_leaf": false,
@@ -84667,6 +86857,15 @@
       "python3"
     ],
     "rpms": {
+      "python-maxminddb-doc-1.4.1-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-maxminddb-1.4.1-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -84742,6 +86941,15 @@
       "scipy"
     ],
     "rpms": {
+      "python-mdp-doc-3.5-12.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-mdp-3.5-12.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -84873,6 +87081,15 @@
       ]
     },
     "rpms": {
+      "python-meld3-1.0.2-9.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-meld3-1.0.2-9.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -85006,12 +87223,22 @@
       "python-ipykernel",
       "python-ipyparallel",
       "python-jedi",
+      "python-jupyter-core",
       "python-nose",
       "python-pexpect",
       "python2",
       "python3"
     ],
     "rpms": {
+      "python-metakernel-doc-0.20.14-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-metakernel-0.20.14-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -85230,6 +87457,15 @@
       "python3"
     ],
     "rpms": {
+      "python-microversion-parse-doc-0.1.3-10.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-microversion-parse-0.1.3-10.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -85984,6 +88220,15 @@
       "python3"
     ],
     "rpms": {
+      "python-molecule-doc-2.16-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-molecule-2.16-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -86015,6 +88260,15 @@
       "python3"
     ],
     "rpms": {
+      "python-mongoengine-doc-0.15.3-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-mongoengine-0.15.3-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -86345,6 +88599,15 @@
       "python3"
     ],
     "rpms": {
+      "python-mpd2-doc-0.5.5-10.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-mpd2-0.5.5-10.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -86419,6 +88682,15 @@
       "python3"
     ],
     "rpms": {
+      "python-mplcursors-doc-0.2.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-mplcursors-0.2.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -86444,6 +88716,15 @@
       "python3"
     ],
     "rpms": {
+      "python-mpmath-doc-1.0.0-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-mpmath-1.0.0-3.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -86611,6 +88892,26 @@
     },
     "status": "released"
   },
+  "python-mtTkinter": {
+    "build_deps": [
+      "python2"
+    ],
+    "deps": [
+      "python2"
+    ],
+    "rpms": {
+      "python2-mttkinter-0.4-17.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      }
+    },
+    "status": "idle"
+  },
   "python-mtg": {
     "build_deps": [
       "python-cssselect",
@@ -86713,6 +89014,15 @@
       "python3"
     ],
     "rpms": {
+      "python-multilib-conf-1.2-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-multilib-1.2-6.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -86740,7 +89050,10 @@
         }
       }
     },
-    "status": "released"
+    "status": "released",
+    "unversioned_requirers": [
+      "python-multilib"
+    ]
   },
   "python-munch": {
     "build_deps": [
@@ -86856,6 +89169,15 @@
       "python3"
     ],
     "rpms": {
+      "python-murano-pkg-check-doc-0.3.0-9.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-murano-pkg-check-0.3.0-9.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -86921,6 +89243,15 @@
     },
     "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
     "rpms": {
+      "python-muranoclient-doc-1.0.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-muranoclient-1.0.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -86970,6 +89301,24 @@
       "scipy"
     ],
     "rpms": {
+      "python-music21-common-2.2.1-12.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-music21-doc-2.2.1-12.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-music21-2.2.1-12.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -86993,7 +89342,10 @@
         }
       }
     },
-    "status": "legacy-leaf"
+    "status": "legacy-leaf",
+    "unversioned_requirers": [
+      "python-music21"
+    ]
   },
   "python-musicbrainz2": {
     "build_deps": [
@@ -87069,6 +89421,15 @@
       "python3"
     ],
     "rpms": {
+      "python-mutagen-doc-1.41.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-mutagen-1.41.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -87561,6 +89922,15 @@
       "python3"
     ],
     "rpms": {
+      "python-nb2plots-docs-0.6-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-nb2plots-0.6-2.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -87624,6 +89994,15 @@
       ]
     },
     "rpms": {
+      "python-nbconvert-doc-5.3.1-10.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-nbconvert-5.3.1-10.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -87717,6 +90096,15 @@
       "python3"
     ],
     "rpms": {
+      "python-nbsphinx-doc-0.2.17-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-nbsphinx-0.2.17-4.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -87748,6 +90136,15 @@
       ]
     },
     "rpms": {
+      "python-nbxmpp-doc-0.6.6-4.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-nbxmpp-0.6.6-4.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -88022,6 +90419,15 @@
       "python3"
     ],
     "rpms": {
+      "python-neovim-doc-0.2.6-4.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-neovim-0.2.6-4.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -88346,6 +90752,15 @@
           "/usr/bin/python2": 2
         }
       },
+      "python-networking-bigswitch-doc-2015.3.12-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-networking-bigswitch-2015.3.12-5.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -88377,6 +90792,15 @@
       ]
     },
     "rpms": {
+      "python-networkmanager-doc-2.1-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-networkmanager-2.1-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -88429,6 +90853,15 @@
       "scipy"
     ],
     "rpms": {
+      "python-networkx-doc-2.2-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-networkx-2.2-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -88497,6 +90930,15 @@
       ]
     },
     "rpms": {
+      "python-neutronclient-doc-6.7.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-neutronclient-6.7.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -88572,6 +91014,15 @@
       ]
     },
     "rpms": {
+      "python-ngram-doc-3.3.0-14.git20161104.325e279.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-ngram-3.3.0-14.git20161104.325e279.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -88756,6 +91207,15 @@
       "python3"
     ],
     "rpms": {
+      "python-nixio-doc-1.4.6-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-nixio-1.4.6-1.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -88950,6 +91410,15 @@
       "python3"
     ],
     "rpms": {
+      "python-nose-docs-1.3.7-21.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-nose-1.3.7-21.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -89294,6 +91763,7 @@
     "build_deps": [
       "python-cov-core",
       "python-mock",
+      "python-rpm-macros",
       "python-setuptools",
       "python-six",
       "python2",
@@ -89349,6 +91819,15 @@
       "python3"
     ],
     "rpms": {
+      "python-nose_fixes-doc-1.3-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-nose_fixes-1.3-6.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -89502,6 +91981,15 @@
       "python3"
     ],
     "rpms": {
+      "python-notebook-doc-5.6.0-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-notebook-5.6.0-2.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -89564,6 +92052,15 @@
       ]
     },
     "rpms": {
+      "python-novaclient-doc-1:10.1.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-novaclient-1:10.1.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -89669,6 +92166,15 @@
       "python2"
     ],
     "rpms": {
+      "python-nsdf-doc-0.0-9.git9621ced.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-nsdf-0.0-9.git9621ced.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -89695,6 +92201,15 @@
       "python3"
     ],
     "rpms": {
+      "python-nss-doc-1.0.1-13.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-nss-1.0.1-13.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -89957,6 +92472,15 @@
       "python3"
     ],
     "rpms": {
+      "python-numpy-stl-doc-2.7.0-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-numpy-stl-2.7.0-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -90180,6 +92704,15 @@
       "python3"
     ],
     "rpms": {
+      "python-oauth2client-doc-4.1.2-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oauth2client-4.1.2-6.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -90341,6 +92874,15 @@
       "subunit"
     ],
     "rpms": {
+      "python-octaviaclient-doc-1.3.0-6.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-octaviaclient-1.3.0-6.fc30": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -90578,6 +93120,15 @@
       "python3"
     ],
     "rpms": {
+      "python-oletools-doc-0.51-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oletools-0.51-6.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -90985,6 +93536,15 @@
       "python3"
     ],
     "rpms": {
+      "python-openstack-doc-tools-doc-1.8.0-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-openstack-doc-tools-1.8.0-4.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -91074,6 +93634,24 @@
       ]
     },
     "rpms": {
+      "python-openstackclient-doc-3.14.1-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-openstackclient-lang-3.14.1-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-openstackclient-3.14.1-4.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -91099,7 +93677,10 @@
         }
       }
     },
-    "status": "released"
+    "status": "released",
+    "unversioned_requirers": [
+      "python-openstackclient"
+    ]
   },
   "python-openstackdocstheme": {
     "build_deps": [
@@ -91120,6 +93701,15 @@
       "python3"
     ],
     "rpms": {
+      "python-openstackdocstheme-doc-1.23.2-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-openstackdocstheme-1.23.2-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -91217,6 +93807,15 @@
       ]
     },
     "rpms": {
+      "python-openstacksdk-doc-0.12.0-5.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-openstacksdk-0.12.0-5.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -91481,6 +94080,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-os-client-config-doc-1.28.0-5.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-os-client-config-1.28.0-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -91491,6 +94099,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-os-client-config-doc-1.28.0-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released",
@@ -91519,6 +94136,15 @@
       "python3"
     ],
     "rpms": {
+      "python-os-service-types-doc-1.1.0-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-os-service-types-1.1.0-6.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -91572,6 +94198,15 @@
     },
     "note": "A single package depends on both Python 2 and Python 3.\nIt should be split into a python2 and python3 subpackages to prevent it from always dragging the py2 dependency in.",
     "rpms": {
+      "python-os-testr-doc-0.8.0-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-os-testr-0.8.0-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -91596,6 +94231,15 @@
           "/usr/bin/python3": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-os-testr-doc-0.8.0-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "mispackaged",
@@ -91638,6 +94282,15 @@
       "python3"
     ],
     "rpms": {
+      "python-os-win-doc-2.2.0-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-os-win-2.2.0-6.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -91714,6 +94367,15 @@
       "python3"
     ],
     "rpms": {
+      "python-osc-lib-doc-1.9.0-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-osc-lib-1.9.0-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -91797,6 +94459,15 @@
       "python3"
     ],
     "rpms": {
+      "python-oslo-cache-lang-1.28.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-cache-1.28.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -91842,7 +94513,10 @@
         }
       }
     },
-    "status": "released"
+    "status": "released",
+    "unversioned_requirers": [
+      "python-oslo-cache"
+    ]
   },
   "python-oslo-concurrency": {
     "build_deps": [
@@ -91886,6 +94560,24 @@
       ]
     },
     "rpms": {
+      "python-oslo-concurrency-doc-3.25.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-oslo-concurrency-lang-3.25.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-concurrency-3.25.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -91935,7 +94627,8 @@
     },
     "status": "released",
     "unversioned_requirers": [
-      "python-glance-store"
+      "python-glance-store",
+      "python-oslo-concurrency"
     ]
   },
   "python-oslo-config": {
@@ -91981,6 +94674,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-oslo-config-doc-2:5.2.0-3.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-oslo-config-2:5.2.0-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -91994,7 +94696,7 @@
         }
       }
     },
-    "status": "released",
+    "status": "idle",
     "unversioned_requirers": [
       "python-glance-store",
       "python-networking-bigswitch",
@@ -92027,6 +94729,15 @@
       ]
     },
     "rpms": {
+      "python-oslo-context-doc-2.20.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python-oslo-context-tests-2.20.0-1.fc30": {
         "almost_leaf": true,
         "is_misnamed": true,
@@ -92131,6 +94842,24 @@
       ]
     },
     "rpms": {
+      "python-oslo-db-doc-4.33.1-6.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-oslo-db-lang-4.33.1-6.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-db-4.33.1-6.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -92178,6 +94907,7 @@
     },
     "status": "released",
     "unversioned_requirers": [
+      "python-oslo-db",
       "python-subunit2sql"
     ]
   },
@@ -92202,6 +94932,24 @@
       "python3"
     ],
     "rpms": {
+      "python-oslo-i18n-doc-3.19.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-oslo-i18n-lang-3.19.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-i18n-3.19.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -92230,7 +94978,8 @@
       "python-aodhclient",
       "python-congressclient",
       "python-glance-store",
-      "python-openstackclient"
+      "python-openstackclient",
+      "python-oslo-i18n"
     ]
   },
   "python-oslo-log": {
@@ -92284,6 +95033,24 @@
       ]
     },
     "rpms": {
+      "python-oslo-log-doc-3.36.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-oslo-log-lang-3.36.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-log-3.36.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -92337,7 +95104,8 @@
     ],
     "unversioned_requirers": [
       "python-congressclient",
-      "python-networking-bigswitch"
+      "python-networking-bigswitch",
+      "python-oslo-log"
     ]
   },
   "python-oslo-messaging": {
@@ -92413,6 +95181,15 @@
       "python3"
     ],
     "rpms": {
+      "python-oslo-messaging-doc-5.35.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-messaging-5.35.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -92516,6 +95293,24 @@
       ]
     },
     "rpms": {
+      "python-oslo-middleware-doc-3.34.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-oslo-middleware-lang-3.34.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-middleware-3.34.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -92561,7 +95356,10 @@
         }
       }
     },
-    "status": "released"
+    "status": "released",
+    "unversioned_requirers": [
+      "python-oslo-middleware"
+    ]
   },
   "python-oslo-policy": {
     "build_deps": [
@@ -92611,6 +95409,24 @@
     "nonblocking": true,
     "note": "The Python 3 package is missing binaries available in a Python 2 package.\n",
     "rpms": {
+      "python-oslo-policy-doc-1.33.2-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-oslo-policy-lang-1.33.2-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-policy-1.33.2-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -92660,6 +95476,9 @@
     "status": "mispackaged",
     "tracking_bugs": [
       "https://bugzilla.redhat.com/show_bug.cgi?id=1432186"
+    ],
+    "unversioned_requirers": [
+      "python-oslo-policy"
     ]
   },
   "python-oslo-privsep": {
@@ -92701,6 +95520,24 @@
       ]
     },
     "rpms": {
+      "python-oslo-privsep-doc-1.13.0-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-oslo-privsep-lang-1.13.0-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-privsep-1.13.0-7.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -92751,6 +95588,9 @@
     "status": "legacy-leaf",
     "tracking_bugs": [
       "https://bugzilla.redhat.com/show_bug.cgi?id=1432186"
+    ],
+    "unversioned_requirers": [
+      "python-oslo-privsep"
     ]
   },
   "python-oslo-reports": {
@@ -92793,6 +95633,15 @@
       ]
     },
     "rpms": {
+      "python-oslo-reports-doc-1.26.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-reports-1.26.0-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -92886,6 +95735,15 @@
     "nonblocking": true,
     "note": "The Python 3 package is missing binaries available in a Python 2 package.\n",
     "rpms": {
+      "python-oslo-rootwrap-doc-5.13.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-rootwrap-5.13.0-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -92979,6 +95837,15 @@
       ]
     },
     "rpms": {
+      "python-oslo-serialization-doc-2.24.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-serialization-2.24.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -93094,6 +95961,15 @@
       ]
     },
     "rpms": {
+      "python-oslo-service-doc-1.29.0-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-service-1.29.0-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -93247,6 +96123,24 @@
       ]
     },
     "rpms": {
+      "python-oslo-utils-doc-3.35.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-oslo-utils-lang-3.35.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-utils-3.35.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -93302,6 +96196,7 @@
       "python-glance-store",
       "python-networking-bigswitch",
       "python-openstackclient",
+      "python-oslo-utils",
       "python-tooz"
     ]
   },
@@ -93353,6 +96248,24 @@
       "pytz"
     ],
     "rpms": {
+      "python-oslo-versionedobjects-doc-1.31.3-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-oslo-versionedobjects-lang-1.31.3-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-versionedobjects-1.31.3-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -93398,7 +96311,10 @@
         }
       }
     },
-    "status": "legacy-leaf"
+    "status": "legacy-leaf",
+    "unversioned_requirers": [
+      "python-oslo-versionedobjects"
+    ]
   },
   "python-oslo-vmware": {
     "build_deps": [
@@ -93452,6 +96368,24 @@
       "subunit"
     ],
     "rpms": {
+      "python-oslo-vmware-doc-2.26.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-oslo-vmware-lang-2.26.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-oslo-vmware-2.26.0-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -93497,7 +96431,10 @@
         }
       }
     },
-    "status": "legacy-leaf"
+    "status": "legacy-leaf",
+    "unversioned_requirers": [
+      "python-oslo-vmware"
+    ]
   },
   "python-oslotest": {
     "build_deps": [
@@ -93632,6 +96569,15 @@
       "python3"
     ],
     "rpms": {
+      "python-osrf-pycommon-doc-0.1.5-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-osrf-pycommon-0.1.5-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -93705,6 +96651,15 @@
       "python3"
     ],
     "rpms": {
+      "python-packaging-doc-17.1-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-packaging-17.1-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -93969,6 +96924,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pankoclient-doc-0.3.0-7.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-pankoclient-0.3.0-7.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -94070,6 +97034,15 @@
       "python3"
     ],
     "rpms": {
+      "python-paramiko-doc-2.4.2-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-paramiko-2.4.2-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -94185,6 +97158,15 @@
       "python3"
     ],
     "rpms": {
+      "python-parsedatetime-doc-2.4-9.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-parsedatetime-2.4-9.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -94773,6 +97755,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-patsy-doc-0.5.0-5.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -95462,6 +98453,24 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-persistent-devel-4.4.2-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python2-persistent-doc-4.4.2-1.fc30": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-persistent-4.4.2-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -95473,6 +98482,24 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-persistent-devel-4.4.2-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python3-persistent-doc-4.4.2-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -95868,6 +98895,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-pika-doc-0.12.0-3.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-pika-0.12.0-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -95878,6 +98914,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-pika-doc-0.12.0-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -95942,6 +98987,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pikepdf-doc-0.3.5-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-pikepdf-0.3.5-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -96003,6 +99057,15 @@
           "python2-devel = 2.7.15-10.fc30": 2
         }
       },
+      "python2-pillow-doc-5.3.0-1.fc30": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pillow-qt-5.3.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -96051,6 +99114,15 @@
           "python3-devel": 3,
           "python3-devel = 3.7.0-10.fc30": 3
         }
+      },
+      "python3-pillow-doc-5.3.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "python3-pillow-qt-5.3.0-1.fc30": {
         "almost_leaf": false,
@@ -96104,6 +99176,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-pint-doc-0.6-15.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-pint-0.6-15.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -96114,6 +99195,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-pint-doc-0.6-15.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "legacy-leaf"
@@ -96132,6 +99222,38 @@
       "python3"
     ],
     "rpms": {
+      "python-pip-doc-18.0-4.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-pip-wheel-18.0-4.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [
+            "jython",
+            "pypy",
+            "pypy3",
+            "python34",
+            "python35",
+            "python36"
+          ],
+          "run_time": [
+            "jython",
+            "pypy",
+            "pypy3",
+            "python34",
+            "python35",
+            "python36"
+          ]
+        },
+        "py_deps": {}
+      },
       "python2-pip-18.0-4.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -96161,7 +99283,16 @@
     },
     "status": "released",
     "unversioned_requirers": [
-      "mesos"
+      "jython",
+      "mesos",
+      "pypy",
+      "pypy3",
+      "python-virtualenv",
+      "python2",
+      "python3",
+      "python34",
+      "python35",
+      "python36"
     ]
   },
   "python-pivy": {
@@ -96238,6 +99369,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pkginfo-doc-1.4.2-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pkginfo-1.4.2-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -96342,6 +99482,15 @@
       "python3"
     ],
     "rpms": {
+      "python-plaster-doc-0.5-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-plaster-0.5-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -96729,6 +99878,7 @@
   },
   "python-poppler-qt4": {
     "build_deps": [
+      "PyQt4",
       "python3",
       "sip"
     ],
@@ -96800,6 +99950,15 @@
       "python3"
     ],
     "rpms": {
+      "python-portalocker-doc-1.2.1-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-portalocker-1.2.1-2.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -96840,6 +99999,15 @@
       "python3"
     ],
     "rpms": {
+      "python-positional-doc-1.1.1-9.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-positional-1.1.1-9.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -97616,6 +100784,15 @@
       "python3"
     ],
     "rpms": {
+      "python-psycopg2-doc-2.7.5-4.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-psycopg2-2.7.5-4.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -98106,6 +101283,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pyasn1-doc-0.3.7-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pyasn1-0.3.7-4.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -98223,6 +101409,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pybtex-doc-0.21-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pybtex-0.21-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -98324,6 +101519,15 @@
       ]
     },
     "rpms": {
+      "python-pycadf-common-2.4.0-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pycadf-2.4.0-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -98349,7 +101553,8 @@
     },
     "status": "released",
     "unversioned_requirers": [
-      "python-ceilometermiddleware"
+      "python-ceilometermiddleware",
+      "python-pycadf"
     ]
   },
   "python-pycallgraph": {
@@ -98394,6 +101599,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pycares-doc-2.3.0-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pycares-2.3.0-4.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -99045,13 +102259,24 @@
       "wxPython"
     ],
     "deps": [
+      "PyQt4",
       "python-Traits",
       "python-pygments",
       "python-traitsui",
       "python2",
-      "python3"
+      "python3",
+      "wxPython"
     ],
     "rpms": {
+      "python-pyface-doc-6.0.0-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pyface-6.0.0-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -99063,6 +102288,24 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-pyface-qt-6.0.0-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python2-pyface-wx-6.0.0-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-pyface-6.0.0-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -99073,9 +102316,18 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-pyface-qt-6.0.0-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
-    "status": "released"
+    "status": "idle"
   },
   "python-pyfakefs": {
     "build_deps": [
@@ -99250,6 +102502,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pyghmi-doc-1.2.4-4.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-pyghmi-1.2.4-4.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -99289,6 +102550,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pygit2-doc-0.27.2-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-pygit2-0.27.2-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -99371,8 +102641,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [
-            "docco",
-            "python2-docs"
+            "docco"
           ],
           "run_time": [
             "docco"
@@ -99387,8 +102656,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [
-            "hugo",
-            "python3-docs"
+            "hugo"
           ],
           "run_time": [
             "hugo"
@@ -99499,6 +102767,15 @@
       ]
     },
     "rpms": {
+      "python-pygraphviz-doc-1.3-3.rc2.fc29.11": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pygraphviz-1.3-3.rc2.fc29.11": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -99653,6 +102930,15 @@
       ]
     },
     "rpms": {
+      "python-pykalman-doc-0.9.5-21.20140827git2aeb4ad.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-pykalman-0.9.5-21.20140827git2aeb4ad.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -99971,6 +103257,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pymacaroons-pynacl-doc-0.9.3-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pymacaroons-pynacl-0.9.3-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -100068,6 +103363,24 @@
       ]
     },
     "rpms": {
+      "python-pymilter-common-1.0.2-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-pymilter-selinux-1.0.2-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pymilter-1.0.2-4.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -100191,6 +103504,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pymongo-doc-3.7.1-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-bson-3.7.1-2.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -100394,6 +103716,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pynlpl-doc-1.2.7-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-pynlpl-1.2.7-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -100638,6 +103969,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pyperclip-doc-1.6.4-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pyperclip-1.6.4-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -100842,12 +104182,14 @@
   },
   "python-pyqtchart": {
     "build_deps": [
+      "python-qt5",
       "python3",
       "sip"
     ],
     "deps": [
       "python-qt5",
-      "python3"
+      "python3",
+      "qscintilla"
     ],
     "rpms": {
       "python3-pyqtchart-5.11.1-3.fc29": {
@@ -100860,6 +104202,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-pyqtchart-devel-5.11.1-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -100880,6 +104231,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pyqtgraph-doc-0.10.0-8.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-pyqtgraph-0.10.0-8.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -101459,6 +104819,15 @@
       ]
     },
     "rpms": {
+      "python-pysaml2-doc-4.5.0-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pysaml2-4.5.0-4.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -101500,6 +104869,15 @@
       "sympy"
     ],
     "rpms": {
+      "python-pysb-doc-1.0.1-11.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pysb-1.0.1-11.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -101592,6 +104970,15 @@
       ]
     },
     "rpms": {
+      "python-pyside-devel-1.2.4-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-pyside-1.2.4-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -101617,7 +105004,11 @@
         }
       }
     },
-    "status": "released"
+    "status": "released",
+    "unversioned_requirers": [
+      "freecad",
+      "pyside-tools"
+    ]
   },
   "python-pysmell": {
     "build_deps": [
@@ -101779,6 +105170,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-pystray-doc-0.14.3-7.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -103351,6 +106751,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pyuv-doc-1.4.0-13.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-pyuv-1.4.0-13.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -103446,6 +106855,15 @@
       "python3"
     ],
     "rpms": {
+      "python-pywt-doc-1.0.1-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-pywt-1.0.1-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -103746,9 +107164,28 @@
       "python-enum34",
       "python2",
       "python3",
+      "qt5-qtbase",
       "sip"
     ],
     "rpms": {
+      "python-qt5-doc-5.11.3-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-qt5-rpm-macros-5.11.3-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-qt5-5.11.3-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -103771,6 +107208,17 @@
         "py_deps": {
           "python(abi) = 2.7": 2
         }
+      },
+      "python2-qt5-devel-5.11.3-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": [
+            "fawkes"
+          ]
+        },
+        "py_deps": {}
       },
       "python2-qt5-webengine-5.11.3-1.fc30": {
         "almost_leaf": true,
@@ -103816,6 +107264,17 @@
           "python(abi) = 3.7": 3
         }
       },
+      "python3-qt5-devel-5.11.3-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": [
+            "fawkes"
+          ]
+        },
+        "py_deps": {}
+      },
       "python3-qt5-webengine-5.11.3-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -103841,7 +107300,10 @@
     },
     "status": "released",
     "unversioned_requirers": [
-      "calibre"
+      "calibre",
+      "fawkes",
+      "python-qt5",
+      "swatchbooker"
     ]
   },
   "python-qtconsole": {
@@ -103872,6 +107334,15 @@
       ]
     },
     "rpms": {
+      "python-qtconsole-doc-4.3.1-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-qtconsole-4.3.1-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -104533,6 +108004,15 @@
       "python3"
     ],
     "rpms": {
+      "python-releases-doc-1.6.0-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-releases-1.6.0-2.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -104666,6 +108146,15 @@
       "python3"
     ],
     "rpms": {
+      "python-renderspec-doc-1.7.0-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-renderspec-1.7.0-6.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -104718,6 +108207,15 @@
       "python3"
     ],
     "rpms": {
+      "python-reno-doc-2.9.2-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-reno-2.9.2-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -104768,6 +108266,15 @@
       ]
     },
     "rpms": {
+      "python-reportlab-doc-3.4.0-8.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-reportlab-3.4.0-8.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -104913,6 +108420,24 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      }
+    },
+    "status": "released"
+  },
+  "python-repoze-what": {
+    "build_deps": [
+      "python-sphinx"
+    ],
+    "deps": [],
+    "rpms": {
+      "python-repoze-what-docs-1.0.9-21.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -105617,6 +109142,15 @@
       "python3"
     ],
     "rpms": {
+      "python-restauth-doc-0.6.1-17.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-restauth-0.6.1-17.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -105643,6 +109177,15 @@
       "python3"
     ],
     "rpms": {
+      "python-restauth-common-doc-0.6.2-15.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-restauth-common-0.6.2-15.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -106118,6 +109661,15 @@
       "python3"
     ],
     "rpms": {
+      "python-ripozo-doc-1.3.0-10.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-ripozo-1.3.0-10.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -106143,6 +109695,15 @@
       "python3"
     ],
     "rpms": {
+      "python-rjsmin-docs-1.0.12-12.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-rjsmin-1.0.12-12.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -106760,6 +110321,87 @@
     },
     "status": "released"
   },
+  "python-rpm-macros": {
+    "build_deps": [],
+    "deps": [],
+    "rpms": {
+      "python-rpm-macros-3-38.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [
+            "backintime",
+            "python34",
+            "python35"
+          ],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-srpm-macros-3-38.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": [
+            "redhat-rpm-config"
+          ]
+        },
+        "py_deps": {}
+      },
+      "python2-rpm-macros-3-38.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [
+            "ardour5",
+            "jalv",
+            "libpqxx",
+            "suil",
+            "zziplib"
+          ],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python3-rpm-macros-3-38.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [
+            "libglvnd",
+            "pseudo",
+            "spirv-tools"
+          ],
+          "run_time": []
+        },
+        "py_deps": {}
+      }
+    },
+    "status": "released",
+    "unversioned_requirers": [
+      "backintime",
+      "copr-rpmbuild",
+      "ecryptfs-utils",
+      "jpype",
+      "pulp-rpm",
+      "python-aiosmtpd",
+      "python-atpublic",
+      "python-cov-core",
+      "python-flufl-bounce",
+      "python-flufl-i18n",
+      "python-flufl-lock",
+      "python-flufl-testing",
+      "python-iso8601",
+      "python-nose2",
+      "python-rpm-macros",
+      "python2",
+      "python3",
+      "python34",
+      "python35",
+      "redhat-rpm-config"
+    ]
+  },
   "python-rpmfluff": {
     "build_deps": [
       "python2",
@@ -106899,6 +110541,15 @@
       "python3"
     ],
     "rpms": {
+      "python-rsd-lib-doc-0.1.1-7.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-rsd-lib-0.1.1-7.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -106945,6 +110596,15 @@
       "python3"
     ],
     "rpms": {
+      "python-rsdclient-doc-0.1.1-6.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-rsdclient-0.1.1-6.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -107012,6 +110672,15 @@
       "python3"
     ],
     "rpms": {
+      "python-rtslib-doc-2.1.fb69-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-rtslib-2.1.fb69-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -107119,6 +110788,15 @@
       "python3"
     ],
     "rpms": {
+      "python-ruffus-doc-2.7.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-ruffus-2.7.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -107243,6 +110921,15 @@
       ]
     },
     "rpms": {
+      "python-ryu-common-4.27-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-ryu-4.27-2.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -107268,7 +110955,10 @@
         }
       }
     },
-    "status": "legacy-leaf"
+    "status": "legacy-leaf",
+    "unversioned_requirers": [
+      "python-ryu"
+    ]
   },
   "python-s3transfer": {
     "build_deps": [
@@ -107844,6 +111534,15 @@
       ]
     },
     "rpms": {
+      "python-scrapy-doc-1.5.1-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-scrapy-1.5.1-1.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -108081,6 +111780,15 @@
       "python3"
     ],
     "rpms": {
+      "python-seesaw-doc-0.10.0-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-seesaw-0.10.0-3.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -108166,6 +111874,15 @@
       ]
     },
     "rpms": {
+      "python-semantic_version-doc-2.6.0-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-semantic_version-2.6.0-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -108274,6 +111991,15 @@
       ]
     },
     "rpms": {
+      "python-sendgrid-examples-3.6.5-7.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-sendgrid-3.6.5-7.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -108488,12 +112214,34 @@
       "python3"
     ],
     "rpms": {
+      "python-setuptools-wheel-40.4.3-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [
+            "jython",
+            "pypy",
+            "pypy3",
+            "python34",
+            "python35",
+            "python36"
+          ],
+          "run_time": [
+            "jython",
+            "pypy",
+            "pypy3",
+            "python34",
+            "python35",
+            "python36"
+          ]
+        },
+        "py_deps": {}
+      },
       "python2-setuptools-40.4.3-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [
-            "check-mk",
             "dib-utils",
             "gflags",
             "icecat",
@@ -108536,12 +112284,15 @@
       "anki",
       "ceph",
       "emacs-pymacs",
+      "jython",
       "lekhonee",
       "linkchecker",
       "mesos",
       "ninja-ide",
       "pilas",
       "puddletag",
+      "pypy",
+      "pypy3",
       "pyrasite",
       "pysysbot",
       "python-aodhclient",
@@ -108559,7 +112310,13 @@
       "python-subunit2sql",
       "python-sure",
       "python-tooz",
+      "python-virtualenv",
       "python-websocket-client",
+      "python2",
+      "python3",
+      "python34",
+      "python35",
+      "python36",
       "synce-kpm",
       "trademgen",
       "translation-filter",
@@ -109525,6 +113282,15 @@
       ]
     },
     "rpms": {
+      "python-simpy-doc-3.0.9-10.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-simpy-3.0.9-10.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -109773,6 +113539,15 @@
       "python3"
     ],
     "rpms": {
+      "python-slixmpp-doc-1.4.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-slixmpp-1.4.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -109840,6 +113615,15 @@
       "python3"
     ],
     "rpms": {
+      "python-smartcols-doc-0.3.0-5.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-smartcols-0.3.0-5.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -109863,6 +113647,15 @@
       "python3"
     ],
     "rpms": {
+      "python-smbc-doc-1.0.15.4-18.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-smbc-1.0.15.4-18.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -110418,6 +114211,15 @@
       "python3"
     ],
     "rpms": {
+      "python-sortedcontainers-doc-2.0.4-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-sortedcontainers-2.0.4-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -110579,6 +114381,33 @@
       "python3"
     ],
     "rpms": {
+      "python-sphinx-doc-1:1.7.6-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-sphinx-latex-1:1.7.6-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-sphinx-locale-1:1.7.6-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-sphinx-1:1.7.6-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -110608,7 +114437,6 @@
             "nextcloud-client",
             "osgearth",
             "owncloud-client",
-            "python2-docs",
             "seqan2",
             "udis86",
             "yara"
@@ -110645,8 +114473,6 @@
             "php-opencloud-openstack",
             "psi4",
             "py3c",
-            "python-repoze-what",
-            "python3-docs",
             "xtl",
             "zathura"
           ],
@@ -110692,6 +114518,7 @@
       "python-oslo-i18n",
       "python-oslo-service",
       "python-semantic_version",
+      "python-sphinx",
       "python-subunit2sql",
       "python-tooz",
       "python-vitrageclient",
@@ -110827,6 +114654,15 @@
       "python3"
     ],
     "rpms": {
+      "python-sphinx-click-doc-1.0.4-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-sphinx-click-1.0.4-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -111010,6 +114846,15 @@
       "python3"
     ],
     "rpms": {
+      "python2-sphinx-theme-flask-git20130715.1cc4468-15.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-sphinx-theme-flask-git20130715.1cc4468-15.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -111228,6 +115073,15 @@
       "python3"
     ],
     "rpms": {
+      "python-sphinxcontrib-bibtex-doc-0.4.0-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-sphinxcontrib-bibtex-0.4.0-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -111291,6 +115145,15 @@
       "python3"
     ],
     "rpms": {
+      "python-sphinxcontrib-fulltoc-doc-1.2-7.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-sphinxcontrib-fulltoc-1.2-7.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -111867,6 +115730,15 @@
       "python3"
     ],
     "rpms": {
+      "python-sqlalchemy-doc-1.2.11-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-sqlalchemy-1.2.11-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -112246,6 +116118,15 @@
       "python3"
     ],
     "rpms": {
+      "python-statsd-doc-3.2.1-11.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-statsd-3.2.1-11.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -112308,6 +116189,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-statsmodels-doc-0.9.0-3.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-statsmodels-0.9.0-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -112319,6 +116209,15 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-statsmodels-doc-0.9.0-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "legacy-leaf"
@@ -112367,6 +116266,15 @@
       ]
     },
     "rpms": {
+      "python-stem-doc-1.7.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-stem-1.7.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -112415,6 +116323,15 @@
       "subunit"
     ],
     "rpms": {
+      "python-stestr-doc-2.1.0-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-stestr-2.1.0-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -112613,6 +116530,15 @@
       "python3"
     ],
     "rpms": {
+      "python-streamlink-doc-0.14.2-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-streamlink-0.14.2-3.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -112718,6 +116644,7 @@
       "python-sphinxcontrib-programoutput",
       "python-stevedore",
       "python2",
+      "python2-docs",
       "python3"
     ],
     "deps": [
@@ -112735,6 +116662,15 @@
       "python3"
     ],
     "rpms": {
+      "python-subliminal-doc-2.0.5-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-subliminal-2.0.5-7.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -112829,6 +116765,15 @@
       "subunit"
     ],
     "rpms": {
+      "python-subunit2sql-doc-1.9.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-subunit2sql-1.9.0-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -113102,6 +117047,15 @@
       "python3"
     ],
     "rpms": {
+      "python-sushy-doc-1.2.0-6.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-sushy-1.2.0-6.fc30": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -113160,6 +117114,15 @@
       "python3"
     ],
     "rpms": {
+      "python-svg-doc-0.2.2b-17.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-svg-0.2.2b-17.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -113235,6 +117198,15 @@
       ]
     },
     "rpms": {
+      "python-swiftclient-doc-3.5.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-swiftclient-3.5.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -113274,6 +117246,15 @@
       "python3"
     ],
     "rpms": {
+      "python-systemd-doc-234-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-systemd-234-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -113319,6 +117300,15 @@
       ]
     },
     "rpms": {
+      "python-sysv_ipc-examples-0.7.0-12.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-sysv_ipc-0.7.0-12.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -113352,6 +117342,15 @@
       "python3"
     ],
     "rpms": {
+      "python-tables-doc-3.4.4-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-tables-3.4.4-2.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -113561,6 +117560,15 @@
       "subunit"
     ],
     "rpms": {
+      "python-tackerclient-doc-0.11.0-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-tackerclient-0.11.0-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -113733,6 +117741,15 @@
       ]
     },
     "rpms": {
+      "python-taskflow-doc-2.6.0-8.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-taskflow-2.6.0-8.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -114241,6 +118258,15 @@
       "python3"
     ],
     "rpms": {
+      "python-testpath-doc-0.3.1-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-testpath-0.3.1-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -114421,6 +118447,15 @@
       "python3"
     ],
     "rpms": {
+      "python-testtools-doc-2.3.0-9.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-testtools-2.3.0-9.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -114842,6 +118877,7 @@
     "build_deps": [
       "Cython",
       "epydoc",
+      "libgpuarray",
       "numpy",
       "python-flake8",
       "python-nose",
@@ -114868,6 +118904,15 @@
       ]
     },
     "rpms": {
+      "python-theano-doc-1.0.3-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-theano-1.0.3-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -114963,6 +119008,15 @@
       "python2"
     ],
     "rpms": {
+      "python-tilestache-examples-1.49.11-12.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-tilestache-1.49.11-12.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -115102,6 +119156,15 @@
       "python3"
     ],
     "rpms": {
+      "python-tinyrpc-doc-0.9.1-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-tinyrpc-0.9.1-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -115330,6 +119393,15 @@
       "python3"
     ],
     "rpms": {
+      "python-tooz-doc-1.48.0-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-tooz-1.48.0-7.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -115373,6 +119445,15 @@
       "python3"
     ],
     "rpms": {
+      "python-tornado-doc-5.0.2-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-tornado-5.0.2-4.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -115481,6 +119562,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-tosca-parser-doc-1.1.0-1.fc30": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-tosca-parser-1.1.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -115492,6 +119582,15 @@
           "/usr/bin/python3": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-tosca-parser-doc-1.1.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "legacy-leaf"
@@ -115718,6 +119817,15 @@
       "python2"
     ],
     "rpms": {
+      "python-tracing-doc-0.9-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-tracing-0.9-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -115971,6 +120079,15 @@
       "python3"
     ],
     "rpms": {
+      "python-treq-doc-17.8.0-6.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-treq-17.8.0-6.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -116051,9 +120168,19 @@
     ],
     "deps": [
       "numpy",
+      "python-Rtree",
+      "python-colorlog",
+      "python-lxml",
+      "python-msgpack",
       "python-networkx",
+      "python-pillow",
+      "python-pyglet",
+      "python-setuptools",
+      "python-shapely",
+      "python-svg-path",
       "python3",
-      "scipy"
+      "scipy",
+      "sympy"
     ],
     "rpms": {
       "python3-trimesh-2.33.12-1.fc30": {
@@ -116066,6 +120193,24 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-trimesh-all-2.33.12-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python3-trimesh-easy-2.33.12-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -116325,6 +120470,15 @@
     },
     "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
     "rpms": {
+      "python-ttystatus-doc-0.34-7.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-ttystatus-0.34-7.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -117147,6 +121301,15 @@
       "python3"
     ],
     "rpms": {
+      "python-txaio-doc-18.7.1-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-txaio-18.7.1-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -117346,6 +121509,22 @@
     "tracking_bugs": [
       "https://bugzilla.redhat.com/show_bug.cgi?id=1312032"
     ]
+  },
+  "python-typeshed": {
+    "build_deps": [],
+    "deps": [],
+    "rpms": {
+      "python-typeshed-0.1-0.20170615git.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      }
+    },
+    "status": "released"
   },
   "python-tzlocal": {
     "build_deps": [
@@ -117836,6 +122015,15 @@
       "scipy"
     ],
     "rpms": {
+      "python-uranium-doc-3.4.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-uranium-3.4.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -117868,6 +122056,15 @@
       "scipy"
     ],
     "rpms": {
+      "python-uranium-lulzbot-doc-3.2.23-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-uranium-lulzbot-3.2.23-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -118136,6 +122333,15 @@
       "python3"
     ],
     "rpms": {
+      "python-urwidtrees-doc-1.0-9.gitfbcb183.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-urwidtrees-1.0-9.gitfbcb183.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -118174,6 +122380,15 @@
       "pyusb"
     ],
     "rpms": {
+      "python-usbtmc-doc-0.8-6.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-usbtmc-0.8-6.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -118322,6 +122537,7 @@
   },
   "python-varlink": {
     "build_deps": [
+      "python-rpm-macros",
       "python3"
     ],
     "deps": [
@@ -118665,16 +122881,30 @@
   },
   "python-virtualenv": {
     "build_deps": [
+      "python-pip",
+      "python-setuptools",
       "python-sphinx",
+      "python-wheel",
       "python2",
       "python3"
     ],
     "deps": [
+      "python-pip",
       "python-setuptools",
+      "python-wheel",
       "python2",
       "python3"
     ],
     "rpms": {
+      "python-virtualenv-doc-16.0.0-5.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-virtualenv-16.0.0-5.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -118971,6 +123201,24 @@
       "python3"
     ],
     "rpms": {
+      "python-vitrageclient-bash-completion-2.1.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python-vitrageclient-doc-2.1.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-vitrageclient-2.1.0-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -118996,7 +123244,10 @@
         }
       }
     },
-    "status": "legacy-leaf"
+    "status": "legacy-leaf",
+    "unversioned_requirers": [
+      "python-vitrageclient"
+    ]
   },
   "python-vobject": {
     "build_deps": [
@@ -119167,6 +123418,15 @@
       "python3"
     ],
     "rpms": {
+      "python-vxi11-doc-0.9-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-vxi11-0.9-5.fc29": {
         "almost_leaf": true,
         "legacy_leaf": true,
@@ -119567,6 +123827,15 @@
       "python3"
     ],
     "rpms": {
+      "python-webencodings-doc-0.5.1-6.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-webencodings-0.5.1-6.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -119840,6 +124109,15 @@
       ]
     },
     "rpms": {
+      "python-websockify-doc-0.8.0-10.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-websockify-0.8.0-10.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -119987,6 +124265,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-werkzeug-doc-0.14.1-3.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-werkzeug-0.14.1-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -119997,6 +124284,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-werkzeug-doc-0.14.1-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released",
@@ -120016,6 +124312,15 @@
       "python3"
     ],
     "rpms": {
+      "python-wheel-wheel-1:0.32.0-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-wheel-1:0.32.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -120043,7 +124348,8 @@
     },
     "status": "released",
     "unversioned_requirers": [
-      "mesos"
+      "mesos",
+      "python-virtualenv"
     ]
   },
   "python-which": {
@@ -120158,6 +124464,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-whitenoise-doc-4.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -120379,6 +124694,15 @@
       "python3"
     ],
     "rpms": {
+      "python-wrapt-doc-1.10.11-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-wrapt-1.10.11-5.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -120461,6 +124785,15 @@
       "python3"
     ],
     "rpms": {
+      "python-wsgi_intercept-doc-1.2.2-10.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-wsgi_intercept-1.2.2-10.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -120657,6 +124990,15 @@
       "python3"
     ],
     "rpms": {
+      "python-wxpython4-doc-4.0.1-9.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-wxpython4-4.0.1-9.fc29": {
         "almost_leaf": true,
         "legacy_leaf": false,
@@ -120753,6 +125095,15 @@
       "python3"
     ],
     "rpms": {
+      "python-x2go-doc-0.6.0.0-2.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-x2go-0.6.0.0-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -120932,6 +125283,15 @@
       ]
     },
     "rpms": {
+      "python-xlib-doc-0.23-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-xlib-0.23-3.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -121197,6 +125557,15 @@
       "pytz"
     ],
     "rpms": {
+      "python-xmp-toolkit-doc-2.0.1-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-xmp-toolkit-2.0.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -121438,6 +125807,15 @@
       "python3"
     ],
     "rpms": {
+      "python-yapsy-doc-1.11.223-12.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-yapsy-1.11.223-12.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -121471,6 +125849,15 @@
       "python3"
     ],
     "rpms": {
+      "python-yaql-doc-1.1.3-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-yaql-1.1.3-4.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -122589,6 +126976,15 @@
       ]
     },
     "rpms": {
+      "python-zope-i18n-common-4.1.0-11.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-zope-i18n-4.1.0-11.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -122996,10 +127392,14 @@
   },
   "python2": {
     "build_deps": [
+      "python-pip",
+      "python-setuptools",
       "systemtap"
     ],
     "deps": [
+      "python-pip",
       "python-rpm-generators",
+      "python-rpm-macros",
       "python-setuptools"
     ],
     "rpms": {
@@ -123107,7 +127507,6 @@
             "mingw-webkitgtk3",
             "mozilla-adblockplus",
             "non-ntk",
-            "openmpi",
             "openmsx",
             "openni",
             "openni-primesense",
@@ -123117,7 +127516,6 @@
             "php-patchwork-utf8",
             "php-pear-Auth-OpenID",
             "php-punic",
-            "python2-docs",
             "python26",
             "pyzy",
             "qt5-qtwebkit",
@@ -123177,7 +127575,6 @@
             "abrt-server-info-page",
             "anaconda-realmd",
             "apt",
-            "check-mk",
             "deepin-artwork-themes",
             "deepin-icon-theme",
             "dib-utils",
@@ -123215,7 +127612,6 @@
             "nodejs",
             "novnc",
             "oddjob",
-            "openmpi",
             "openscad",
             "openvswitch-ovn-kubernetes",
             "orthanc",
@@ -123223,8 +127619,6 @@
             "pony",
             "putty",
             "py3c",
-            "python-basemap-data",
-            "python-mtTkinter",
             "python-rpi-gpio",
             "qcint",
             "rabbitmq-java-client",
@@ -123303,7 +127697,6 @@
         "non_python_requirers": {
           "build_time": [],
           "run_time": [
-            "python-mtTkinter",
             "scribus-generator"
           ]
         },
@@ -123474,6 +127867,15 @@
           "libpython2.7.so.1.0()(64bit)": 2,
           "python(abi) = 2.7": 2
         }
+      },
+      "python2-astropy-doc-2.0.8-2.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "idle"
@@ -123510,6 +127912,46 @@
           "/usr/bin/python2": 2,
           "python(abi) = 2.7": 2
         }
+      },
+      "python2-django1.11-doc-1.11.15-2.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      }
+    },
+    "status": "idle"
+  },
+  "python2-docs": {
+    "build_deps": [
+      "linkchecker",
+      "python-docutils",
+      "python-pygments",
+      "python-sphinx",
+      "python2"
+    ],
+    "deps": [],
+    "rpms": {
+      "python2-docs-2.7.15-3.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "python2-docs-info-2.7.15-3.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "idle"
@@ -123600,6 +128042,15 @@
           "/usr/bin/python2": 2,
           "python(abi) = 2.7": 2
         }
+      },
+      "python2-ipython-doc-5.8.0-1.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "python2-ipython-sphinx-5.8.0-1.fc29": {
         "almost_leaf": false,
@@ -123720,9 +128171,15 @@
     "status": "idle"
   },
   "python3": {
-    "build_deps": [],
+    "build_deps": [
+      "python-pip",
+      "python-rpm-macros",
+      "python-setuptools"
+    ],
     "deps": [
+      "python-pip",
       "python-rpm-generators",
+      "python-rpm-macros",
       "python-setuptools"
     ],
     "links": {
@@ -123785,7 +128242,6 @@
             "opencc",
             "parted",
             "pseudo",
-            "python3-docs",
             "qemu",
             "qt-creator",
             "realmd",
@@ -123858,7 +128314,6 @@
             "ibus-libpinyin",
             "ibus-libzhuyin",
             "jsoncpp",
-            "libdnet",
             "libevdev",
             "libkkc",
             "libndn-cxx",
@@ -123882,7 +128337,6 @@
             "mythes-en",
             "ninja-build",
             "nodejs",
-            "openmpi",
             "openvswitch-ovn-kubernetes",
             "oscap-anaconda-addon",
             "psi4",
@@ -123918,6 +128372,15 @@
           "python3": 3,
           "python3 = 3.7.0-10.fc30": 3
         }
+      },
+      "python3-libs-3.7.0-10.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "python3-test-3.7.0-10.fc30": {
         "almost_leaf": false,
@@ -124051,8 +128514,32 @@
     },
     "status": "released"
   },
+  "python3-docs": {
+    "build_deps": [
+      "linkchecker",
+      "python-docutils",
+      "python-pygments",
+      "python-sphinx",
+      "python3"
+    ],
+    "deps": [],
+    "rpms": {
+      "python3-docs-3.7.0-0.2.rc1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      }
+    },
+    "status": "released"
+  },
   "python3-exiv2": {
     "build_deps": [
+      "boost",
+      "python-rpm-macros",
       "python3"
     ],
     "deps": [
@@ -124154,6 +128641,7 @@
     ],
     "deps": [
       "python-psutil",
+      "python-typeshed",
       "python3",
       "python3-typed_ast"
     ],
@@ -124202,6 +128690,7 @@
   },
   "python3-poppler-qt5": {
     "build_deps": [
+      "python-qt5",
       "python3",
       "sip"
     ],
@@ -124488,7 +128977,9 @@
       "python3",
       "qt5-qtbase"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "links": {
       "bug": [
         "https://bugzilla.redhat.com/show_bug.cgi?id=1394149",
@@ -124720,6 +129211,7 @@
       "python-pbr",
       "python-pip",
       "python-ply",
+      "python-rpm-macros",
       "python3"
     ],
     "deps": [
@@ -125097,11 +129589,14 @@
   },
   "qhexedit2": {
     "build_deps": [
+      "PyQt4",
+      "python-qt5",
       "qt5-qtbase",
       "sip"
     ],
     "deps": [
-      "python3"
+      "python3",
+      "sip"
     ],
     "rpms": {
       "python3-qhexedit2-0.8.4-1.fc30": {
@@ -125116,6 +129611,15 @@
           "python(abi) = 3.7": 3
         }
       },
+      "python3-qhexedit2-devel-0.8.4-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-qhexedit2-qt5-0.8.4-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -125127,6 +129631,15 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-qhexedit2-qt5-devel-0.8.4-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -125310,6 +129823,15 @@
       "python3"
     ],
     "rpms": {
+      "python-qpid-proton-docs-0.24.0-4.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-qpid-proton-0.24.0-4.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -125347,6 +129869,7 @@
   },
   "qscintilla": {
     "build_deps": [
+      "PyQt4",
       "python-qt5",
       "python2",
       "python3",
@@ -125372,6 +129895,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-qscintilla-devel-2.10.8-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python2-qscintilla-qt5-2.10.8-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -125382,6 +129914,15 @@
         "py_deps": {
           "python(abi) = 2.7": 2
         }
+      },
+      "python2-qscintilla-qt5-devel-2.10.8-1.fc30": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "python3-qscintilla-2.10.8-1.fc30": {
         "almost_leaf": false,
@@ -125394,6 +129935,15 @@
           "python(abi) = 3.7": 3
         }
       },
+      "python3-qscintilla-devel-2.10.8-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-qscintilla-qt5-2.10.8-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -125404,6 +129954,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-qscintilla-qt5-devel-2.10.8-1.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released",
@@ -126686,6 +131245,7 @@
   },
   "rb_libtorrent": {
     "build_deps": [
+      "boost",
       "python-setuptools",
       "python2",
       "python3"
@@ -126753,6 +131313,7 @@
   },
   "rdkit": {
     "build_deps": [
+      "boost",
       "numpy",
       "python3"
     ],
@@ -127192,7 +131753,9 @@
       "python3",
       "qt5-qtbase"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "rpms": {
       "renderdoc-1.1-1.fc29": {
         "almost_leaf": false,
@@ -127855,6 +132418,7 @@
   },
   "rmol": {
     "build_deps": [
+      "boost",
       "python2"
     ],
     "deps": [
@@ -127944,6 +132508,7 @@
     "deps": [
       "ipython",
       "numpy",
+      "python-jupyter-core",
       "python-metakernel",
       "python2",
       "python2-ipython",
@@ -128170,6 +132735,7 @@
       "python-configparser",
       "python-mock",
       "python-munch",
+      "python-rpm-macros",
       "python-setuptools",
       "python3",
       "rpkg"
@@ -128330,6 +132896,15 @@
         "py_deps": {
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-rpmconf-doc-1.0.19-5.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       },
       "rpmconf-1.0.19-5.fc29": {
         "almost_leaf": false,
@@ -129163,6 +133738,8 @@
   },
   "samba": {
     "build_deps": [
+      "libldb",
+      "libtalloc",
       "libtdb",
       "libtevent",
       "python-crypto",
@@ -129468,6 +134045,7 @@
   },
   "scidavis": {
     "build_deps": [
+      "PyQt4",
       "python3",
       "sip"
     ],
@@ -129533,6 +134111,15 @@
           "python(abi) = 2.7": 2
         }
       },
+      "python2-scipy-doc-1.1.0-1.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "python3-scipy-1.1.0-1.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -129544,6 +134131,15 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
+      },
+      "python3-scipy-doc-1.1.0-1.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "released"
@@ -130126,6 +134722,7 @@
   },
   "sevmgr": {
     "build_deps": [
+      "boost",
       "python2"
     ],
     "deps": [
@@ -130488,7 +135085,8 @@
       "python-pillow",
       "python-qt5",
       "python-regex",
-      "python-six"
+      "python-six",
+      "python3"
     ],
     "rpms": {
       "sigil-0.9.10-2.fc30": {
@@ -130540,6 +135138,7 @@
   },
   "simcrs": {
     "build_deps": [
+      "boost",
       "python2"
     ],
     "deps": [
@@ -130570,6 +135169,7 @@
   },
   "simfqt": {
     "build_deps": [
+      "boost",
       "python2"
     ],
     "deps": [
@@ -131941,6 +136541,7 @@
   },
   "stdair": {
     "build_deps": [
+      "boost",
       "python2"
     ],
     "deps": [
@@ -132193,6 +136794,7 @@
   },
   "subdownloader": {
     "build_deps": [
+      "python-qt5",
       "python2"
     ],
     "deps": [
@@ -134215,6 +138817,7 @@
   "swatchbooker": {
     "build_deps": [
       "python-pillow",
+      "python-qt5",
       "python-setuptools",
       "python2"
     ],
@@ -135494,6 +140097,34 @@
     },
     "status": "idle"
   },
+  "texlive": {
+    "build_deps": [],
+    "deps": [],
+    "rpms": {
+      "texlive-python-8:svn27064.0.21-20.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "texlive-python-doc-8:svn27064.0.21-20.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      }
+    },
+    "status": "released",
+    "unversioned_requirers": [
+      "texlive"
+    ]
+  },
   "texlive-base": {
     "build_deps": [
       "python3"
@@ -135513,9 +140144,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [],
-          "run_time": [
-            "texlive"
-          ]
+          "run_time": []
         },
         "py_deps": {
           "/usr/bin/python3": 3
@@ -135526,9 +140155,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [],
-          "run_time": [
-            "texlive"
-          ]
+          "run_time": []
         },
         "py_deps": {
           "/usr/bin/python2.7": 2
@@ -135539,9 +140166,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [],
-          "run_time": [
-            "texlive"
-          ]
+          "run_time": []
         },
         "py_deps": {
           "/usr/bin/python3": 3
@@ -135552,9 +140177,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [],
-          "run_time": [
-            "texlive"
-          ]
+          "run_time": []
         },
         "py_deps": {
           "/usr/bin/python3": 3
@@ -135565,9 +140188,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [],
-          "run_time": [
-            "texlive"
-          ]
+          "run_time": []
         },
         "py_deps": {
           "/usr/bin/python3": 3
@@ -135578,9 +140199,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [],
-          "run_time": [
-            "texlive"
-          ]
+          "run_time": []
         },
         "py_deps": {
           "/usr/bin/python3": 3
@@ -135591,9 +140210,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [],
-          "run_time": [
-            "texlive"
-          ]
+          "run_time": []
         },
         "py_deps": {
           "/usr/bin/python2": 2
@@ -135604,9 +140221,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [],
-          "run_time": [
-            "texlive"
-          ]
+          "run_time": []
         },
         "py_deps": {
           "/usr/bin/python2": 2,
@@ -135618,9 +140233,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [],
-          "run_time": [
-            "texlive"
-          ]
+          "run_time": []
         },
         "py_deps": {
           "/usr/bin/python3": 3
@@ -135859,7 +140472,9 @@
       "python3",
       "qt5-qtbase"
     ],
-    "deps": [],
+    "deps": [
+      "python3"
+    ],
     "rpms": {
       "tiled-plugin-python-1.2.0-1.fc30": {
         "almost_leaf": false,
@@ -137092,6 +141707,7 @@
   },
   "trademgen": {
     "build_deps": [
+      "boost",
       "python-setuptools",
       "python2"
     ],
@@ -137137,6 +141753,7 @@
     ],
     "deps": [
       "python-pip",
+      "python-rpm-macros",
       "python-setuptools",
       "python-six",
       "python-slugify",
@@ -137401,6 +142018,7 @@
   },
   "travelccm": {
     "build_deps": [
+      "boost",
       "python2"
     ],
     "deps": [
@@ -139469,10 +144087,13 @@
     "build_deps": [
       "glib2",
       "libevent",
+      "python-greenlet",
       "python2",
       "python3"
     ],
     "deps": [
+      "python-greenlet",
+      "python-tornado",
       "python2",
       "python3"
     ],
@@ -139532,6 +144153,33 @@
           "python2 = 2.7.15-10.fc30": 2
         }
       },
+      "uwsgi-plugin-python2-gevent-2.0.17.1-2.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "uwsgi-plugin-python2-greenlet-2.0.17.1-2.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "uwsgi-plugin-python2-tornado-2.0.17.1-2.fc29": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
       "uwsgi-plugin-python3-2.0.17.1-2.fc29": {
         "almost_leaf": false,
         "legacy_leaf": false,
@@ -139544,6 +144192,33 @@
           "python3": 3,
           "python3 = 3.7.0-10.fc30": 3
         }
+      },
+      "uwsgi-plugin-python3-gevent-2.0.17.1-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "uwsgi-plugin-python3-greenlet-2.0.17.1-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
+      },
+      "uwsgi-plugin-python3-tornado-2.0.17.1-2.fc29": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {}
       }
     },
     "status": "mispackaged"
@@ -140288,6 +144963,7 @@
   },
   "vegastrike": {
     "build_deps": [
+      "boost",
       "gtk2",
       "python2"
     ],

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -244,6 +244,21 @@ class Py3QueryCommand(dnf.cli.Command):
                     python_versions[pkg].add(n)
                     rpm_pydeps[pkg].add(str(dep))
 
+        # Add packages with 'python?' as a component of their name, if they
+        # haven't been added as dependencies
+        for name, version in {
+            'python': 0,
+            'python2': 2,
+            'python3': 3,
+        }.items():
+            for pattern in '{}-*', '*-{}', '*-{}-*':
+                name_glob = pattern.format(name)
+                query = self.pkg_query.filter(name__glob=name_glob)
+                message = 'Getting {} packages'.format(name_glob)
+                for pkg in progressbar(query, message):
+                    if pkg not in python_versions:
+                        python_versions[pkg].add(version)
+
         # srpm_names: {package: srpm name}
         # by_srpm_name: {srpm name: set of packages}
         srpm_names = {}

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -256,6 +256,9 @@ class Py3QueryCommand(dnf.cli.Command):
                 query = self.pkg_query.filter(name__glob=name_glob)
                 message = 'Getting {} packages'.format(name_glob)
                 for pkg in progressbar(query, message):
+                    if pkg.sourcerpm.startswith('mingw-'):
+                        # Ignore mingw packages
+                        continue
                     if pkg not in python_versions:
                         python_versions[pkg].add(version)
 


### PR DESCRIPTION
#  Track all subpackages with a "python" component in the name

Track all subpackages with `python2`, `python3` or `python` as a
dash-separated component of the name.
For subpackages that don't have a Python dependency (as found by
the existing mechanism), mark them `python2` or `python3`
according to the names. (If it's just `python`, don't mark it
either way.)

This will find a lot of new "misnamed requires".

<s>This should cover `python2-networkx` and similar metapackages, so it
fixes: https://github.com/fedora-python/portingdb/issues/459
</s>

 ## Update Fedora data to pick up plugin changes

**missing -> idle (3)**
- check-mk
- python-mtTkinter
- python2-docs

**missing -> released (8)**
- libdnet
- openmpi
- python-basemap-data
- python-repoze-what
- python-rpm-macros
- python-typeshed
- python3-docs
- texlive

**released -> idle (3)**
- python-docker
- python-oslo-config
- python-pyface

**released -> legacy-leaf (1)**
- nautilus-python

**_Naming status changes_**
**missing -> requires misnamed (12)**
- gedit-plugins
- jython
- pypy
- pypy3
- python34
- python35
- python36
- fawkes
- backintime
- python-rpm-macros
- redhat-rpm-config
- texlive

**requires ok -> requires misnamed (51)**
- ibus
- prepaid-manager-applet
- gcc-python-plugin
- gstreamer-rtsp
- libldb
- livecd-tools
- nbdkit
- python-afl
- python-basemap
- python-cartopy
- python-collectd_systemd
- python-formencode
- python-gencpp
- python-genlisp
- python-genpy
- python-ipykernel
- python-metakernel
- root
- python-multilib
- python-music21
- python-oslo-cache
- python-oslo-concurrency
- python-oslo-db
- python-oslo-log
- python-oslo-middleware
- python-oslo-policy
- python-oslo-privsep
- python-oslo-utils
- python-oslo-versionedobjects
- python-oslo-vmware
- python-virtualenv
- python2
- python3
- pyside-tools
- python-qt5
- swatchbooker
- copr-rpmbuild
- ecryptfs-utils
- jpype
- pulp-rpm
- python-aiosmtpd
- python-atpublic
- python-cov-core
- python-flufl-bounce
- python-flufl-i18n
- python-flufl-lock
- python-flufl-testing
- python-iso8601
- python-nose2
- python-ryu
- python-sphinx
