### PR TITLE
Avoid DB in the naming policy & history

### DIFF
--- a/portingdb/load_data.py
+++ b/portingdb/load_data.py
@@ -74,6 +74,9 @@ def load_from_directories(data, directories):
     )
     packages.update(_pkgs)
 
+    non_python_unversioned_requires = data.setdefault(
+        'non_python_unversioned_requires', {})
+
     groups = data.setdefault('groups', {})
     groups.update(data_from_file(directories, 'groups'))
 
@@ -215,3 +218,7 @@ def load_from_directories(data, directories):
                 requirer['unversioned_requires'][name] = package
                 if package['is_misnamed']:
                     requirer['blocked_requires'][name] = package
+            else:
+                non_python_unversioned_requires.setdefault(
+                    requirer_name, {}
+                )[name] = package

--- a/portingdb/load_data.py
+++ b/portingdb/load_data.py
@@ -103,6 +103,7 @@ def load_from_directories(data, directories):
         package.setdefault('groups', {})
         package.setdefault('tracking_bugs', ())
         package.setdefault('last_link_update', None)
+        package.setdefault('unversioned_requires', {})
 
         maintainer_names = pagure_owner_alias['rpms'].get(name, ())
         package['maintainers'] = package_maintainers = {}
@@ -204,3 +205,9 @@ def load_from_directories(data, directories):
                     names_to_add.add(dep)
                 for dep in packages[name]['build_deps']:
                     names_to_add.add(dep)
+
+    # Update unversioned requirers
+    for name, package in packages.items():
+        for requirer in package.get('unversioned_requirers', ()):
+            if requirer in packages:
+                packages[requirer]['unversioned_requires'][name] = package

--- a/portingdb/load_data.py
+++ b/portingdb/load_data.py
@@ -61,6 +61,10 @@ def load_from_directories(data, directories):
     statuses.update({s['ident']: s
                      for s in data_from_file(directories, 'statuses')})
 
+    naming_statuses = data.setdefault('naming_statuses', {})
+    naming_statuses.update({s['ident']: s
+                           for s in data_from_file(directories, 'naming')})
+
     naming = data.setdefault('naming', {})
     naming.update({s['ident']: s
                    for s in data_from_file(directories, 'naming')})

--- a/portingdb/load_data.py
+++ b/portingdb/load_data.py
@@ -104,6 +104,7 @@ def load_from_directories(data, directories):
         package.setdefault('tracking_bugs', ())
         package.setdefault('last_link_update', None)
         package.setdefault('unversioned_requires', {})
+        package.setdefault('blocked_requires', {})
 
         maintainer_names = pagure_owner_alias['rpms'].get(name, ())
         package['maintainers'] = package_maintainers = {}
@@ -208,6 +209,9 @@ def load_from_directories(data, directories):
 
     # Update unversioned requirers
     for name, package in packages.items():
-        for requirer in package.get('unversioned_requirers', ()):
-            if requirer in packages:
-                packages[requirer]['unversioned_requires'][name] = package
+        for requirer_name in package.get('unversioned_requirers', ()):
+            requirer = packages.get(requirer_name)
+            if requirer:
+                requirer['unversioned_requires'][name] = package
+                if package['is_misnamed']:
+                    requirer['blocked_requires'][name] = package

--- a/portingdb/load_data.py
+++ b/portingdb/load_data.py
@@ -220,7 +220,7 @@ def load_from_directories(data, directories):
             requirer = packages.get(requirer_name)
             if requirer:
                 requirer['unversioned_requires'][name] = package
-                if package['is_misnamed']:
+                if package['is_misnamed'] and package != requirer:
                     requirer['blocked_requires'][name] = package
             else:
                 non_python_unversioned_requires.setdefault(

--- a/portingdb/templates/_base.html
+++ b/portingdb/templates/_base.html
@@ -33,12 +33,14 @@
 {%- endmacro %}
 
 {% macro pkglink(pkg, ignore_misnamed=False, ignore_unversioned_requires=False) -%}
-    {{ pkglink_icon(pkg) }}&nbsp;{{ pkglink_text(pkg) }}
-    {{ pkg_naming_badge(
-        pkg,
-        ignore_misnamed=ignore_misnamed,
-        ignore_unversioned_requires=ignore_unversioned_requires,
-    ) }}
+    {{ pkglink_icon(pkg) }}&nbsp;<a href="{{ url_for('package', pkg=pkg.name) }}">
+        {{- pkg.name -}}
+        {{- pkg_naming_badge(
+            pkg,
+            ignore_misnamed=ignore_misnamed,
+            ignore_unversioned_requires=ignore_unversioned_requires,
+        ) -}}
+    </a>
 {%- endmacro %}
 
 {% macro pkglink_icon(pkg) -%}

--- a/portingdb/templates/_base.html
+++ b/portingdb/templates/_base.html
@@ -16,15 +16,15 @@
     {% endif %}
 {%- endmacro %}
 
-{% macro status_minibadge(thing) -%}
+{% macro naming_status_badge(thing) -%}
     {% if not thing or thing.ident == 'unknown' %}
-        <span class="minibadge"
+        <span class="naming-badge"
             style="border: 1px solid #CCCCCC; background-color: transparent; color: #CCCCCC;"
             title="Unknown"
         >
         </span>
     {% else %}
-        <span class="minibadge"
+        <span class="naming-badge"
             style="background-color: #{{ thing.color }} !important;"
             title="{{ thing.name }}"
         >
@@ -155,11 +155,7 @@
         {% endif %}
         {% for status, num in status_counts %}
             <span class="progress-legend-item">
-            <span class="minibadge"
-                style="background-color: #{{ status.color }} !important;"
-                title="{{ status }}"
-            >
-            </span>
+            {{ status_badge(status) }}
             {{ num }} {{ status.name }}{% if not loop.last %};{% endif %}
             </span>
         {% endfor %}
@@ -259,7 +255,7 @@
             .progress-with-legend {
                 margin-bottom: 1em;
             }
-            .minibadge {
+            .naming-badge {
                 display: inline-block;
                 position: relative;
                 top: 2px;
@@ -268,7 +264,7 @@
                 border-radius: 3px;
                 padding: 2px;
             }
-            .list-group .minibadge {
+            .list-group .naming-badge {
                 float: right;
             }
             .rpm-list {

--- a/portingdb/templates/_base.html
+++ b/portingdb/templates/_base.html
@@ -49,13 +49,24 @@
     {% if pkg['is_misnamed'] %}
         {{ misnamed_badge() }}
     {% endif %}
+    {% if pkg['unversioned_requires'] %}
+        {{ unversioned_requires_badge() }}
+    {% endif %}
 {%- endmacro %}
 
 {% macro misnamed_badge() -%}
     <span
         class="naming-badge"
-        style="background-color: F0AD4E !important;"
+        style="background-color: #F0AD4E !important;"
         title="Misnamed package"
+    ></span>
+{%- endmacro %}
+
+{% macro unversioned_requires_badge() -%}
+    <span
+        class="naming-badge"
+        style="background-color: #8c6699 !important;"
+        title="Ambiguous Requires"
     ></span>
 {%- endmacro %}
 

--- a/portingdb/templates/_base.html
+++ b/portingdb/templates/_base.html
@@ -32,9 +32,13 @@
     {% endif %}
 {%- endmacro %}
 
-{% macro pkglink(pkg) -%}
+{% macro pkglink(pkg, ignore_misnamed=False, ignore_unversioned_requires=False) -%}
     {{ pkglink_icon(pkg) }}&nbsp;{{ pkglink_text(pkg) }}
-    {{- pkg_naming_badge(pkg) -}}
+    {{ pkg_naming_badge(
+        pkg,
+        ignore_misnamed=ignore_misnamed,
+        ignore_unversioned_requires=ignore_unversioned_requires,
+    ) }}
 {%- endmacro %}
 
 {% macro pkglink_icon(pkg) -%}
@@ -45,11 +49,11 @@
     <a href="{{ url_for('package', pkg=pkg.name) }}">{{ pkg.name }}</a>
 {%- endmacro %}
 
-{% macro pkg_naming_badge(pkg) -%}
-    {% if pkg['is_misnamed'] %}
+{% macro pkg_naming_badge(pkg, ignore_misnamed=False, ignore_unversioned_requires=False) -%}
+    {% if pkg['is_misnamed'] and not ignore_misnamed %}
         {{ misnamed_badge() }}
     {% endif %}
-    {% if pkg['unversioned_requires'] %}
+    {% if pkg['unversioned_requires'] and not ignore_unversioned_requires %}
         {{ unversioned_requires_badge( pkg['blocked_requires']) }}
     {% endif %}
 {%- endmacro %}
@@ -254,6 +258,13 @@
             .simple-pkg-list {
                 list-style-type: none;
                 padding-left: 1em;
+            }
+            .simple-pkg-list>li {
+                padding-left: 0.5em;
+                text-indent: -0.5em;
+            }
+            .simple-pkg-list>li * {
+                text-indent: 0;
             }
             .dependents .badge {
                 min-width: 1ex;

--- a/portingdb/templates/_base.html
+++ b/portingdb/templates/_base.html
@@ -34,6 +34,7 @@
 
 {% macro pkglink(pkg) -%}
     {{ pkglink_icon(pkg) }}&nbsp;{{ pkglink_text(pkg) }}
+    {{- pkg_naming_badge(pkg) -}}
 {%- endmacro %}
 
 {% macro pkglink_icon(pkg) -%}
@@ -42,6 +43,20 @@
 
 {% macro pkglink_text(pkg) -%}
     <a href="{{ url_for('package', pkg=pkg.name) }}">{{ pkg.name }}</a>
+{%- endmacro %}
+
+{% macro pkg_naming_badge(pkg) -%}
+    {% if pkg['is_misnamed'] %}
+        {{ misnamed_badge() }}
+    {% endif %}
+{%- endmacro %}
+
+{% macro misnamed_badge() -%}
+    <span
+        class="naming-badge"
+        style="background-color: F0AD4E !important;"
+        title="Misnamed package"
+    ></span>
 {%- endmacro %}
 
 {% macro print_deptree(pkgs) -%}

--- a/portingdb/templates/_base.html
+++ b/portingdb/templates/_base.html
@@ -50,24 +50,28 @@
         {{ misnamed_badge() }}
     {% endif %}
     {% if pkg['unversioned_requires'] %}
-        {{ unversioned_requires_badge() }}
+        {{ unversioned_requires_badge( pkg['blocked_requires']) }}
     {% endif %}
 {%- endmacro %}
 
-{% macro misnamed_badge() -%}
+{% macro _naming_badge(color, text) -%}
     <span
         class="naming-badge"
-        style="background-color: #F0AD4E !important;"
-        title="Misnamed package"
+        style="background-color: #{{ color }} !important;"
+        title="{{ text }}"
     ></span>
 {%- endmacro %}
 
-{% macro unversioned_requires_badge() -%}
-    <span
-        class="naming-badge"
-        style="background-color: #8c6699 !important;"
-        title="Ambiguous Requires"
-    ></span>
+{% macro misnamed_badge() -%}
+    {{ _naming_badge('F0AD4E', 'Misnamed package') }}
+{%- endmacro %}
+
+{% macro unversioned_requires_badge(blocked) -%}
+    {%- if blocked -%}
+        {{ _naming_badge('a65959', 'Ambiguous Requires (blocked)') }}
+    {%- else -%}
+        {{ _naming_badge('8c6699', 'Ambiguous Requires') }}
+    {%- endif -%}
 {%- endmacro %}
 
 {% macro print_deptree(pkgs) -%}

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -294,18 +294,6 @@
                 versions this report is based on.
             </div>
             <h2><a href="{{url_for('namingpolicy') }}">Naming Policy</a></h2>
-            <div class="progress">
-                {% for status, count in naming_progress %}
-                <div
-                    class="progress-bar" role="progressbar"
-                    aria-valuenow="{{ count }}"
-                    aria-valuemin="0" aria-valuemax="{{ total_pkg_count }}"
-                    style="width: {{ 100 * count / total_pkg_count }}%;
-                           background-color: #{{ status.color }} !important;
-                           color: black;">
-                </div>
-                {% endfor %}
-            </div>
             <div>Tracking packages which do not comply with <a href="https://fedoraproject.org/wiki/Packaging:Naming?rd=Packaging:NamingGuidelines#Python_source_package_naming" target="_blank">Python package naming guidelines</a></div>
             <ul class="list-group">
                 {% for status, count in naming_progress %}

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -278,7 +278,7 @@
                     {% set status = statuses[status] %}
                     {% if num_packages %}
                         <li class="list-group-item">
-                            {{ status_minibadge(status) }}
+                            {{ status_badge(status) }}
                             <a href="#{{ status.ident }}">{{ status.name }}</a>
                             <div><small>{{ status.description }}</small></div>
                         </li>
@@ -312,7 +312,7 @@
                 <li class="list-group-item">
                     {% if status.ident != 'name-correct' %}<a href="{{url_for('namingpolicy') }}#{{ status.ident }}">{% endif %}
                     {{ count }}
-                    {{ status_minibadge(status) }}
+                    {{ naming_status_badge(status) }}
                     <strong>{{ status.name }}</strong>
                     {% if status.ident != 'name-correct' %}</a>{% endif %}
                     <div><small>{{ status.short_description }}</small></div>

--- a/portingdb/templates/namingpolicy.html
+++ b/portingdb/templates/namingpolicy.html
@@ -15,7 +15,6 @@
         <h1>Naming Policy Violations</h1>
     </div>
     <div class="col-md-12">
-        {{ progress_summary(progress, total_packages) }}
         <p>
             This is a dashboard to track various naming scheme violations in Python packages:
             <ul>

--- a/portingdb/templates/namingpolicy.html
+++ b/portingdb/templates/namingpolicy.html
@@ -143,13 +143,6 @@
             </li>
         </ul>
         <h3>Visualizations</h3>
-        You can also look at the progress in the form of a
-        <a href="{{ url_for('piechart_namingpolicy') }}">pie chart</a>.
-        <div>
-            <a href="{{ url_for('piechart_namingpolicy') }}">
-                <img src="{{ url_for('piechart_namingpolicy') }}">
-            </a>
-        </div>
         <div>
             You may also see a
             <a href="{{ url_for('history_naming') }}">graph of the progress history</a>

--- a/portingdb/templates/namingpolicy.html
+++ b/portingdb/templates/namingpolicy.html
@@ -21,7 +21,7 @@
             <ul>
                 {% for (name_status, total), packages in data %}
                 <li>
-                    {{ status_minibadge(name_status) }}
+                    {{ naming_status_badge(name_status) }}
                     <strong>{{ name_status.name }}</strong> -
                     {{ name_status.violation | safe }}
                 </li>
@@ -73,7 +73,7 @@
         <ul class="list-group">
             {% for (name_status, total), packages in data %}
             <li class="list-group-item">
-                {{ status_minibadge(name_status) }}
+                {{ naming_status_badge(name_status) }}
                 <a href="#{{ name_status.ident }}">
                     {{ total }}
                     <strong>{{ name_status.name }}</strong>
@@ -86,7 +86,7 @@
         <ul class="list-group">
             {% for name_status, total, packages in data_outside_portingdb %}
             <li class="list-group-item">
-                {{ status_minibadge(name_status) }}
+                {{ naming_status_badge(name_status) }}
                 <a href="#{{ name_status.ident }}-non-python">
                     {{ total }}
                     <strong>{{ name_status.name }}</strong>

--- a/portingdb/templates/namingpolicy.html
+++ b/portingdb/templates/namingpolicy.html
@@ -16,82 +16,131 @@
     </div>
     <div class="col-md-12">
         <p>
-            This is a dashboard to track various naming scheme violations in Python packages:
-            <ul>
-                {% for (name_status, total), packages in data %}
-                <li>
-                    {{ naming_status_badge(name_status) }}
-                    <strong>{{ name_status.name }}</strong> -
-                    {{ name_status.violation | safe }}
-                </li>
-                {% endfor %}
-            </ul>
+            This is a dashboard to track various naming scheme violations in Python packages.
+        </p>
+        <p>
+            Specifically, this tracks the use of “unversioned” <code>python</code>
+            in all package names, Provides, Requires, etc.
+            It should be replaced by "versioned” variants <code>python2</code>
+            or <code>python3</code>.
+        </p>
+        <p>
             We encourage to follow the new guidelines to avoid a range of issues
-            when upstream support for Python 2 ends and <i>python</i> means Python 3 in Fedora.
+            when upstream support for Python 2 ends and <code>python</code>
+            means Python 3 in Fedora.
         </p>
     </div>
     <div class="col-md-9">
-        {% for (name_status, total), packages in data %}
-        <h3 id="{{ name_status.ident }}">
-            {{ total }} packages - {{ name_status.name }}
+        <h3 id="name-misnamed">
+            Misnamed subpackage ({{ misnamed | length }})
         </h3>
-        <div>{{ name_status.description | safe }}</div>
-        <div>
-            {% for pkg in packages %}
-            <span class="pkgstatus-icon" style="background-color: {{ name_status.color }}">&nbsp;</span>&nbsp;{{ pkglink_text(pkg) }}
+        {{ misnamed_badge() }}
+        The naming scheme of (at least) one of the binary RPMs
+        does not comply with the naming policy. Please refer to the
+        <a href="https://python-rpm-porting.readthedocs.io/en/latest/naming-scheme.html">
+        Python RPM Porting Guide</a> for more information and instructions on
+        the changes needed.
+        <ul class="simple-pkg-list">
+            {% for name, pkg in misnamed.items() | sort %}
+                <li>{{ pkglink(pkg, ignore_misnamed=True) }}</li>
             {% endfor %}
-        </div>
-        {% endfor %}
-        <h3>Non Python Packages</h3>
-        <div>There are also non Python packages which are not tracked in Python Porting Database, but depend on Python packages and use the unversioned naming scheme in run-time or build-time requirements.</div>
-        {% for name_status, total, packages in data_outside_portingdb %}
-        <h4 id="{{ name_status.ident }}-non-python">
-            {{ total }} packages - {{ name_status.name }}
+        </ul>
+
+        <h3>
+            Ambiguous Requires
+            ({{
+                (requires_unblocked | length)
+                + (requires_blocked | length)
+                + (nonpython | length)
+            }})
+        </h3>
+        Some (Build)Requires use “unversioned” <code>python</code>.
+
+        <h4 id="require-misnamed">Unblocked</h4>
+        {{ unversioned_requires_badge(blocked=False) }}
+        For {{ requires_unblocked | length }} Python packages, explicitly versioned
+        names (e.g. <code>python2-foo</code>) are available and should be used.
+        <ul class="simple-pkg-list" style="column-width: 10em;">
+            {% for name, pkg in requires_unblocked.items() | sort %}
+                <li>{{ pkglink(pkg, ignore_unversioned_requires=True) }}</li>
+            {% endfor %}
+        </ul>
+
+        <h4 id="require-blocked">Blocked</h4>
+        {{ unversioned_requires_badge(blocked=True) }}
+        For {{ requires_blocked | length }} Python packages, explicitly versioned
+        names (e.g. <code>python2-foo</code>) may not be available.
+        These packages are waiting for some misnamed packages to be renamed.
+        <ul class="simple-pkg-list">
+            {% for name, pkg in requires_blocked.items() | sort %}
+                <li>{{ pkglink(pkg, ignore_unversioned_requires=True) }}</li>
+            {% endfor %}
+        </ul>
+
+        <h4 id="require-misnamed-non-python">
+            Non-Python Packages
         </h4>
+        <div>
+            There are also {{ nonpython | length }} non-Python packages which
+            are not tracked in Python Porting Database, but depend on Python
+            packages and use the unversioned naming scheme in run-time or
+            build-time requirements.
+        </div>
+
         <table class="table table-striped table-condensed table-hovered">
             <tr>
                 <th>Package</th>
                 <th>Links</th>
             </tr>
-
-            {% for pkg in packages %}
+            {% for name, blocked in nonpython.items() %}
             <tr>
                 <td>
-                    <span class="pkgstatus-icon" style="background-color: {{ name_status.color }}">&nbsp;</span>&nbsp;{{ pkg[0] }}
+                    {{ name }}
+                    {% if blocked %}
+                        {{ unversioned_requires_badge(blocked=blocked) }}
+                        (Blocked!)
+                    {% endif %}
                 </td>
                 <td>
-                    <a target="_blank" href="https://src.fedoraproject.org/rpms/{{ pkg[0] }}/">Pagure</a>,
-                    <a target="_blank" href="https://src.fedoraproject.org/rpms/{{ pkg[0] }}/blob/master/f/{{ pkg[0] }}.spec">spec</a>
+                    <a target="_blank" href="https://src.fedoraproject.org/rpms/{{ name }}/">Pagure</a>,
+                    <a target="_blank" href="https://src.fedoraproject.org/rpms/{{ name }}/blob/master/f/{{ name }}.spec">spec</a>
                 </td>
             </tr>
             {% endfor %}
         </table>
-        {% endfor %}
     </div>
     <div class="col-md-3">
         <ul class="list-group">
-            {% for (name_status, total), packages in data %}
             <li class="list-group-item">
-                {{ naming_status_badge(name_status) }}
-                <a href="#{{ name_status.ident }}">
-                    {{ total }}
-                    <strong>{{ name_status.name }}</strong>
-                </a>
-                <div><small>{{ name_status.short_description }}</small></div>
-            </li>
-            {% endfor %}
-        </ul>
-        <h3>Non Python Packages</h3>
-        <ul class="list-group">
-            {% for name_status, total, packages in data_outside_portingdb %}
-            <li class="list-group-item">
-                {{ naming_status_badge(name_status) }}
-                <a href="#{{ name_status.ident }}-non-python">
-                    {{ total }}
-                    <strong>{{ name_status.name }}</strong>
+                {{ misnamed_badge() }}
+                <a href="#name-misnamed">
+                    {{ misnamed | length }}
+                    <strong>Misnamed subpackage</strong>
                 </a>
             </li>
-            {% endfor %}
+            <li class="list-group-item">
+                {{ unversioned_requires_badge(blocked=False) }}
+                <a href="#require-misnamed">
+                    {{ requires_unblocked | length }}
+                    <strong>Unblocked</strong>
+                    Ambiguous Requires
+                </a>
+            </li>
+            <li class="list-group-item">
+                {{ unversioned_requires_badge(blocked=True) }}
+                <a href="#require-blocked">
+                    {{ requires_blocked | length }}
+                    <strong>Blocked</strong>
+                    Ambiguous Requires
+                </a>
+            </li>
+            <li class="list-group-item">
+                <a href="#require-misnamed-non-python">
+                    {{ nonpython | length }}
+                    <strong>Non-Python</strong>
+                    Ambiguous Requires
+                </a>
+            </li>
         </ul>
         <h3>Visualizations</h3>
         You can also look at the progress in the form of a

--- a/portingdb/templates/package.html
+++ b/portingdb/templates/package.html
@@ -62,6 +62,17 @@
                 </div>
                 <br>
             {% endif %}
+            {% if pkg.unversioned_requires %}
+                <div>
+                    {{ unversioned_requires_badge() }}
+                    This package has Ambiguous Requires (or BuildRequires):
+                    it uses unversioned <code>python</code>, rather than
+                    <code>python2</code> or <code>python3</code>,
+                    to refer to other packages.
+                    The Python version should always be given explicitly.
+                </div>
+                <br>
+            {% endif %}
             <div>
                 <img src="https://fedoraproject.org/static/images/favicon.ico">
                 See
@@ -116,6 +127,20 @@
                                     </ul>
                                 </li>
                             {% endfor %}
+                            </ul>
+                        </div>
+                    {% endif %}
+                    {% if pkg.unversioned_requires %}
+                        <div>
+                            <h3>Ambiguous Requires</h3>
+                            {{ unversioned_requires_badge() }}
+                            This package has ambiguous (Build)Requires for:
+                            <ul class='simple-pkg-list'>
+                                {% for name, p in pkg.unversioned_requires.items() %}
+                                    <li>
+                                        {{ pkglink(p) }}
+                                    </li>
+                                {% endfor %}
                             </ul>
                         </div>
                     {% endif %}

--- a/portingdb/templates/package.html
+++ b/portingdb/templates/package.html
@@ -54,6 +54,14 @@
                 {{ pkg.status_obj.instructions | md }}
             </div>
             <br>
+            {% if pkg['is_misnamed'] %}
+                <div>
+                    {{ misnamed_badge() }}
+                    This package does not conform to Fedora's Python naming guidelines.
+                    See individual RPMs below.
+                </div>
+                <br>
+            {% endif %}
             <div>
                 <img src="https://fedoraproject.org/static/images/favicon.ico">
                 See
@@ -80,10 +88,10 @@
                                 <li>
                                     {{ rpm_name | format_rpm_name }}
                                     {% if rpm.get('is_misnamed') %}
-                                    <span class="badge"
+                                    <span class="naming-badge"
                                           style="background-color: #F0AD4E !important;"
                                           title="The RPM name does not comply with Python package naming guidelines"
-                                    >x</span>
+                                    ></span>
                                     {% endif %}
                                     {{ rpm_leaf_badge(rpm) }}
                                     <ul class="fa-ul">

--- a/portingdb/templates/package.html
+++ b/portingdb/templates/package.html
@@ -64,13 +64,20 @@
             {% endif %}
             {% if pkg.unversioned_requires %}
                 <div>
-                    {{ unversioned_requires_badge() }}
+                    {{ unversioned_requires_badge(blocked=False) }}
                     This package has Ambiguous Requires (or BuildRequires):
                     it uses unversioned <code>python</code>, rather than
                     <code>python2</code> or <code>python3</code>,
                     to refer to other packages.
                     The Python version should always be given explicitly.
                 </div>
+                {% if pkg.blocked_requires %}
+                    <div>
+                        {{ unversioned_requires_badge(pkg.blocked_requires) }}
+                        Note that some required packages may not provide the
+                        necessary versioned Provides yet.
+                    </div>
+                {% endif %}
                 <br>
             {% endif %}
             <div>
@@ -133,10 +140,10 @@
                     {% if pkg.unversioned_requires %}
                         <div>
                             <h3>Ambiguous Requires</h3>
-                            {{ unversioned_requires_badge() }}
+                            {{ unversioned_requires_badge(pkg['blocked_requires']) }}
                             This package has ambiguous (Build)Requires for:
                             <ul class='simple-pkg-list'>
-                                {% for name, p in pkg.unversioned_requires.items() %}
+                                {% for name, p in pkg.unversioned_requires.items() | sort %}
                                     <li>
                                         {{ pkglink(p) }}
                                     </li>

--- a/scripts/get-history.py
+++ b/scripts/get-history.py
@@ -10,6 +10,7 @@ with commits that aren't in it appended.
 Outputs to stdout.
 """
 
+import collections
 import subprocess
 import tempfile
 import shutil
@@ -17,12 +18,10 @@ import csv
 import sys
 import os
 
-from sqlalchemy import create_engine, select, func
 import click
 
 from portingdb import tables
-from portingdb.htmlreport import get_naming_policy_progress
-from portingdb.load import get_db
+from portingdb.load_data import get_data
 
 
 HISTORY_END_COMMIT = '9c4e924da9ede05b4d8903a622240259dfa0e2e5'
@@ -50,21 +49,17 @@ d854079db4d805c4f4f07ad5a4a7c94811030979
 """.splitlines())
 
 
-def get_history_package_numbers(db, commit, date):
+def get_history_package_numbers(data, commit, date):
     """Get number of packages for each status.
     """
-    prev_batch = []
+    result = []
     all_statuses = [
         "blocked", "py3-only", "dropped", "idle", "in-progress",
         "released", "legacy-leaf", "mispackaged"]
 
-    columns = [tables.Package.status, func.count()]
-    query = select(columns).select_from(tables.Package.__table__)
-    query = query.group_by(tables.Package.status)
-
-    package_numbers = {status: num_packages
-                       for status, num_packages
-                       in db.execute(query)}
+    package_numbers = collections.Counter(
+        package['status'] for package in data['packages'].values()
+    )
     for status in all_statuses:
         row = {
             'commit': commit,
@@ -72,24 +67,31 @@ def get_history_package_numbers(db, commit, date):
             'status': status,
             'num_packages': package_numbers.get(status, 0),
         }
-        prev_batch.append(row)
-    return prev_batch
+        result.append(row)
+    return result
 
 
 def get_history_naming_package_numbers(data, commit, date):
     """Get number of packages for each naming policy violation.
     """
-    prev_batch = []
-    progress, _ = get_naming_policy_progress(db)
-    for status, count in progress[1:]:
+    result = []
+
+    progress = collections.Counter(
+        'Misnamed Subpackage' if package['is_misnamed'] else
+        'Blocked' if package['blocked_requires'] else
+        'Ambiguous Requires' if package['unversioned_requires'] else
+        'OK'
+        for package in data['packages'].values()
+    )
+    for status_name in 'Misnamed Subpackage', 'Ambiguous Requires', 'Blocked':
         row = {
             'commit': commit,
             'date': date,
-            'status': status.name,
-            'num_packages': count,
+            'status': status_name,
+            'num_packages': progress[status_name],
         }
-        prev_batch.append(row)
-    return prev_batch
+        result.append(row)
+    return result
 
 
 @click.command(help=__doc__)
@@ -117,7 +119,6 @@ def main(update, naming):
     try:
         tmpclone = os.path.join(tmpdir, 'tmp_clone')
         tmpdata = os.path.join(tmpclone, 'data')
-        tmpdb = os.path.join(tmpclone, 'tmp-portingdb.sqlite')
         run(['git', 'clone', '.', tmpclone])
         prev_data_hash = None
         prev_batch = []
@@ -142,30 +143,19 @@ def main(update, naming):
                 prev_commit = commit
                 print('{},{} - skipping'.format(prev_commit, prev_date),
                       file=sys.stderr)
+                continue
             prev_batch = []
 
             # Note: we don't remove files that didn't exist in the old
             # version.
             run(['git', 'checkout', commit, '--', 'data'], cwd=tmpclone)
-            try:
-                run(['python3', '-m', 'portingdb',
-                    '--datadir', tmpdata,
-                    '--db', tmpdb,
-                    'load'])
-            except Exception as e:
-                typename = type(e).__name__
-                print(f'{prev_commit},{prev_date} - ERROR: {typename}: {e}',
-                      file=sys.stderr)
 
-            engine = create_engine('sqlite:///' + os.path.abspath(tmpdb))
-            db = get_db(engine=engine)
+            data = get_data(tmpdata)
 
             if naming:
-                prev_batch = get_history_naming_package_numbers(db, commit, date)
+                prev_batch = get_history_naming_package_numbers(data, commit, date)
             else:
-                prev_batch = get_history_package_numbers(db, commit, date)
-
-            os.unlink(tmpdb)
+                prev_batch = get_history_package_numbers(data, commit, date)
 
             prev_data_hash = data_hash
         for row in prev_batch:

--- a/scripts/get-history.py
+++ b/scripts/get-history.py
@@ -76,7 +76,7 @@ def get_history_package_numbers(db, commit, date):
     return prev_batch
 
 
-def get_history_naming_package_numbers(db, commit, date):
+def get_history_naming_package_numbers(data, commit, date):
     """Get number of packages for each naming policy violation.
     """
     prev_batch = []

--- a/scripts/get-history.py
+++ b/scripts/get-history.py
@@ -60,6 +60,10 @@ def get_history_package_numbers(data, commit, date):
     package_numbers = collections.Counter(
         package['status'] for package in data['packages'].values()
     )
+    if 'released' not in package_numbers and date < '2018':
+        # With data from before April 2017, "released" (dual-support) packages
+        # are counted as py3-only
+        package_numbers['released'] = package_numbers.pop('py3-only')
     for status in all_statuses:
         row = {
             'commit': commit,


### PR DESCRIPTION
Switch Naming policy to use data in dicts, rather than going through the DB.

There are some changes to how naming policy is calculated: mainly, Misnamed packages no longer block themselves. Also, instead of a single status, a package can both be Misnamed and have Ambiguous Requires, and "Blocked" is a subset of Ambiguous Requires.

There are also changes to how naming policy is displayed: mainly, the status shows up as a colorful box on nearly any mention of a package in the HTML report.