### PR TITLE
Update Fedora data

### DIFF
--- a/data/fedora.json
+++ b/data/fedora.json
@@ -188,7 +188,7 @@
     ],
     "deps": [],
     "rpms": {
-      "Carla-2.0.0-0.7.20181225git2f3a442.fc30": {
+      "Carla-2.0.0-0.8.20181225git2f3a442.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -595,7 +595,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "python3-openimageio-2.0.3-1.fc30": {
+      "python3-openimageio-2.0.4-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -1764,7 +1764,7 @@
       "python2"
     ],
     "rpms": {
-      "afftools-3.7.16-7.fc29": {
+      "afftools-3.7.16-8.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -15928,7 +15928,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "glibc-benchtests-2.28.9000-28.fc30": {
+      "glibc-benchtests-2.28.9000-29.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -16120,7 +16120,7 @@
       "bug": [
         "https://bugzilla.redhat.com/show_bug.cgi?id=1323263",
         "CLOSED RAWHIDE",
-        "2017-12-15 23:24:30"
+        "2019-01-09 12:54:42"
       ]
     },
     "rpms": {
@@ -16266,7 +16266,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "gnome-builder-3.31.1-1.fc30": {
+      "gnome-builder-3.31.1-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -16957,7 +16957,7 @@
       "python2"
     ],
     "rpms": {
-      "gnumeric-1:1.12.41-2.fc29": {
+      "gnumeric-1:1.12.44-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -18310,36 +18310,6 @@
     },
     "status": "idle"
   },
-  "gst-inspector": {
-    "build_deps": [
-      "python2"
-    ],
-    "deps": [
-      "gstreamer-python",
-      "pygobject2",
-      "pygtk2",
-      "python2"
-    ],
-    "rpms": {
-      "gst-inspector-0.4-19.fc29": {
-        "almost_leaf": true,
-        "legacy_leaf": true,
-        "non_python_requirers": {
-          "build_time": [],
-          "run_time": []
-        },
-        "py_deps": {
-          "/usr/bin/python2": 2,
-          "pygobject2": 2,
-          "pygobject2 = 2.28.7-4.fc29": 2,
-          "pygtk2": 2,
-          "pygtk2 = 2.24.0-23.fc29": 2,
-          "python(abi) = 2.7": 2
-        }
-      }
-    },
-    "status": "idle"
-  },
   "gstreamer-python": {
     "build_deps": [
       "pygobject2",
@@ -18832,7 +18802,8 @@
             "xwota",
             "xwxapt",
             "xzgv",
-            "yersinia"
+            "yersinia",
+            "zbar"
           ],
           "run_time": [
             "GtkAda",
@@ -18889,7 +18860,8 @@
             "unity-gtk-module",
             "wxGTK",
             "wxGTK3",
-            "xfce4-panel"
+            "xfce4-panel",
+            "zbar"
           ]
         },
         "py_deps": {
@@ -19089,7 +19061,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "gvfs-tests-1.39.1-1.fc30": {
+      "gvfs-tests-1.39.4-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -21445,7 +21417,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "itstool-2.0.5-1.fc30": {
+      "itstool-2.0.5-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -21832,24 +21804,6 @@
     },
     "status": "idle"
   },
-  "kcbench-data": {
-    "build_deps": [],
-    "deps": [],
-    "rpms": {
-      "kcbench-data-4.4-0.1-23.fc29": {
-        "almost_leaf": false,
-        "legacy_leaf": false,
-        "non_python_requirers": {
-          "build_time": [],
-          "run_time": []
-        },
-        "py_deps": {
-          "/usr/bin/python2": 2
-        }
-      }
-    },
-    "status": "idle"
-  },
   "kde-dev-scripts": {
     "build_deps": [
       "python2"
@@ -21897,7 +21851,6 @@
       "python2"
     ],
     "deps": [
-      "kcbench-data",
       "python2"
     ],
     "links": {
@@ -23355,7 +23308,7 @@
       "python2"
     ],
     "rpms": {
-      "python2-langtable-0.0.39-2.fc30": {
+      "python2-langtable-0.0.40-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -23366,7 +23319,7 @@
           "python(abi) = 2.7": 2
         }
       },
-      "python3-langtable-0.0.39-2.fc30": {
+      "python3-langtable-0.0.40-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -23474,7 +23427,7 @@
       "bug": [
         "https://bugzilla.redhat.com/show_bug.cgi?id=1600711",
         "NEW",
-        "2018-08-14 09:53:47"
+        "2019-01-07 15:02:01"
       ]
     },
     "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
@@ -24368,7 +24321,7 @@
       "bug": [
         "https://bugzilla.redhat.com/show_bug.cgi?id=1370773",
         "CLOSED RAWHIDE",
-        "2017-03-09 00:17:15"
+        "2019-01-09 12:54:42"
       ]
     },
     "rpms": {
@@ -24448,7 +24401,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "libgda-tools-1:5.2.8-1.fc29": {
+      "libgda-tools-1:5.2.8-2.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -24783,7 +24736,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "libinput-utils-1.12.4-1.fc30": {
+      "libinput-utils-1.12.5-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -25591,7 +25544,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "python3-libreport-2.9.7-1.fc30": {
+      "python3-libreport-2.9.7-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -26494,7 +26447,7 @@
       "python2"
     ],
     "rpms": {
-      "python2-libxml2-2.9.8-4.fc29": {
+      "python2-libxml2-2.9.8-5.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -26509,7 +26462,7 @@
           "python(abi) = 2.7": 2
         }
       },
-      "python3-libxml2-2.9.8-4.fc29": {
+      "python3-libxml2-2.9.8-5.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -28093,7 +28046,7 @@
       ]
     },
     "rpms": {
-      "meld-3.19.1-1.fc30": {
+      "meld-3.20.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -29933,7 +29886,7 @@
       ]
     },
     "rpms": {
-      "nbdkit-python-plugin-common-1.9.8-1.fc30": {
+      "nbdkit-python-plugin-common-1.9.9-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -29942,7 +29895,7 @@
         },
         "py_deps": {}
       },
-      "nbdkit-python2-plugin-1.9.8-1.fc30": {
+      "nbdkit-python2-plugin-1.9.9-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -29953,7 +29906,7 @@
           "libpython2.7.so.1.0()(64bit)": 2
         }
       },
-      "nbdkit-python3-plugin-1.9.8-1.fc30": {
+      "nbdkit-python3-plugin-1.9.9-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -33127,7 +33080,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "pagure-5.1.4-2.fc30": {
+      "pagure-5.2-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -33139,7 +33092,7 @@
           "python(abi) = 3.7": 3
         }
       },
-      "pagure-ev-5.1.4-2.fc30": {
+      "pagure-ev-5.2-2.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -33157,7 +33110,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "pagure-dist-git-0.12-1.fc30": {
+      "pagure-dist-git-1.2.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -34156,9 +34109,7 @@
   },
   "pitivi": {
     "build_deps": [],
-    "deps": [
-      "pygobject3"
-    ],
+    "deps": [],
     "links": {
       "bug": [
         "https://bugzilla.redhat.com/show_bug.cgi?id=1391153",
@@ -34167,7 +34118,7 @@
       ]
     },
     "rpms": {
-      "pitivi-0.99-4.fc29": {
+      "pitivi-0.99-6.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -34474,7 +34425,7 @@
       "wxPython"
     ],
     "rpms": {
-      "playonlinux-4.3.3-1.fc30": {
+      "playonlinux-4.3.4-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -34579,7 +34530,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "python3-podman-2:0.12.2-23.dev.git4e0c0ec.fc30": {
+      "python3-podman-2:0.12.2-25.dev.gitfaa2462.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -34590,7 +34541,7 @@
           "python(abi) = 3.7": 3
         }
       },
-      "python3-pypodman-2:0.12.2-23.dev.git4e0c0ec.fc30": {
+      "python3-pypodman-2:0.12.2-25.dev.gitfaa2462.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -35085,7 +35036,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "plater-1:2.0.0-0.7.rc5.fc29": {
+      "plater-1:2.0.0-0.8.rc5.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -35096,7 +35047,7 @@
           "/usr/bin/python3": 3
         }
       },
-      "printrun-common-1:2.0.0-0.7.rc5.fc29": {
+      "printrun-common-1:2.0.0-0.8.rc5.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -35109,7 +35060,7 @@
           "python(abi) = 3.7": 3
         }
       },
-      "pronsole-1:2.0.0-0.7.rc5.fc29": {
+      "pronsole-1:2.0.0-0.8.rc5.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -35120,7 +35071,7 @@
           "/usr/bin/python3": 3
         }
       },
-      "pronterface-1:2.0.0-0.7.rc5.fc29": {
+      "pronterface-1:2.0.0-0.8.rc5.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -36751,9 +36702,7 @@
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
-          "build_time": [
-            "libmateweather"
-          ],
+          "build_time": [],
           "run_time": []
         },
         "py_deps": {
@@ -36959,9 +36908,7 @@
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
-          "build_time": [
-            "libmateweather"
-          ],
+          "build_time": [],
           "run_time": []
         },
         "py_deps": {
@@ -38487,7 +38434,7 @@
       "python2"
     ],
     "rpms": {
-      "python2-pysnmp-4.4.6-1.fc30": {
+      "python2-pysnmp-4.4.8-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -38498,7 +38445,7 @@
           "python(abi) = 2.7": 2
         }
       },
-      "python3-pysnmp-4.4.6-1.fc30": {
+      "python3-pysnmp-4.4.8-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -43577,8 +43524,8 @@
     ],
     "rpms": {
       "python2-backports-shutil_which-3.5.1-7.fc29": {
-        "almost_leaf": false,
-        "legacy_leaf": false,
+        "almost_leaf": true,
+        "legacy_leaf": true,
         "non_python_requirers": {
           "build_time": [],
           "run_time": []
@@ -45263,6 +45210,26 @@
           "run_time": []
         },
         "py_deps": {
+          "libpython3.7m.so.1.0()(64bit)": 3,
+          "python(abi) = 3.7": 3
+        }
+      }
+    },
+    "status": "released"
+  },
+  "python-bsddb3": {
+    "build_deps": [],
+    "deps": [],
+    "rpms": {
+      "python3-bsddb3-6.2.6-3.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {
+          "/usr/bin/python3": 3,
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python(abi) = 3.7": 3
         }
@@ -50744,7 +50711,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "python-django-bash-completion-2.1.2-1.fc30": {
+      "python-django-bash-completion-2.1.5-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -50753,7 +50720,7 @@
         },
         "py_deps": {}
       },
-      "python3-django-2.1.2-1.fc30": {
+      "python3-django-2.1.5-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -50765,7 +50732,7 @@
           "python(abi) = 3.7": 3
         }
       },
-      "python3-django-doc-2.1.2-1.fc30": {
+      "python3-django-doc-2.1.5-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -61246,8 +61213,8 @@
     ],
     "rpms": {
       "python2-iso-639-0.4.5-5.fc29": {
-        "almost_leaf": false,
-        "legacy_leaf": false,
+        "almost_leaf": true,
+        "legacy_leaf": true,
         "non_python_requirers": {
           "build_time": [],
           "run_time": []
@@ -61268,7 +61235,7 @@
         }
       }
     },
-    "status": "released"
+    "status": "legacy-leaf"
   },
   "python-iso3166": {
     "build_deps": [
@@ -61279,8 +61246,8 @@
     ],
     "rpms": {
       "python2-iso3166-0.9-1.fc29": {
-        "almost_leaf": false,
-        "legacy_leaf": false,
+        "almost_leaf": true,
+        "legacy_leaf": true,
         "non_python_requirers": {
           "build_time": [],
           "run_time": []
@@ -61301,7 +61268,7 @@
         }
       }
     },
-    "status": "released"
+    "status": "legacy-leaf"
   },
   "python-iso639": {
     "build_deps": [],
@@ -66646,6 +66613,8 @@
       "python-mock",
       "python-moksha-common",
       "python-nose",
+      "python-pyasn1",
+      "python-service-identity",
       "python-setuptools",
       "python-six",
       "python-stomper",
@@ -66658,15 +66627,18 @@
     "deps": [
       "python-daemon",
       "python-moksha-common",
+      "python-pyasn1",
+      "python-service-identity",
       "python-six",
       "python-stomper",
       "python-twisted",
       "python-txws",
       "python-txzmq",
+      "python-zmq",
       "python2"
     ],
     "rpms": {
-      "python2-moksha-hub-1.5.13-2.0.1cb025525.fc30": {
+      "python2-moksha-hub-1.5.14-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -66682,7 +66654,7 @@
           "python(abi) = 2.7": 2
         }
       },
-      "python3-moksha-hub-1.5.13-2.0.1cb025525.fc30": {
+      "python3-moksha-hub-1.5.14-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -67640,11 +67612,10 @@
     "links": {
       "bug": [
         "https://bugzilla.redhat.com/show_bug.cgi?id=1560485",
-        "NEW",
-        "2018-11-12 17:18:29"
+        "CLOSED WONTFIX",
+        "2019-01-09 14:27:51"
       ]
     },
-    "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
     "rpms": {
       "python-muranoclient-doc-1.0.1-2.fc30": {
         "almost_leaf": false,
@@ -67668,7 +67639,7 @@
         }
       }
     },
-    "status": "mispackaged"
+    "status": "idle"
   },
   "python-music21": {
     "build_deps": [
@@ -73315,8 +73286,8 @@
     ],
     "rpms": {
       "python2-parse-1.8.4-1.fc29": {
-        "almost_leaf": false,
-        "legacy_leaf": false,
+        "almost_leaf": true,
+        "legacy_leaf": true,
         "non_python_requirers": {
           "build_time": [],
           "run_time": []
@@ -73337,7 +73308,7 @@
         }
       }
     },
-    "status": "released"
+    "status": "legacy-leaf"
   },
   "python-parse_type": {
     "build_deps": [],
@@ -74808,7 +74779,7 @@
       "python2"
     ],
     "rpms": {
-      "python2-pillow-5.3.0-1.fc30": {
+      "python2-pillow-5.4.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -74822,7 +74793,7 @@
           "python(abi) = 2.7": 2
         }
       },
-      "python2-pillow-devel-5.3.0-1.fc30": {
+      "python2-pillow-devel-5.4.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -74834,7 +74805,7 @@
           "python2-devel = 2.7.15-10.fc30": 2
         }
       },
-      "python2-pillow-doc-5.3.0-1.fc30": {
+      "python2-pillow-doc-5.4.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -74843,7 +74814,7 @@
         },
         "py_deps": {}
       },
-      "python2-pillow-qt-5.3.0-1.fc30": {
+      "python2-pillow-qt-5.4.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -74856,7 +74827,7 @@
           "python(abi) = 2.7": 2
         }
       },
-      "python2-pillow-tk-5.3.0-1.fc30": {
+      "python2-pillow-tk-5.4.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -74868,7 +74839,7 @@
           "python(abi) = 2.7": 2
         }
       },
-      "python3-pillow-5.3.0-1.fc30": {
+      "python3-pillow-5.4.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -74880,7 +74851,7 @@
           "python(abi) = 3.7": 3
         }
       },
-      "python3-pillow-devel-5.3.0-1.fc30": {
+      "python3-pillow-devel-5.4.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -74892,7 +74863,7 @@
           "python3-devel = 3.7.2-1.fc30": 3
         }
       },
-      "python3-pillow-doc-5.3.0-1.fc30": {
+      "python3-pillow-doc-5.4.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -74901,7 +74872,7 @@
         },
         "py_deps": {}
       },
-      "python3-pillow-qt-5.3.0-1.fc30": {
+      "python3-pillow-qt-5.4.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -74912,7 +74883,7 @@
           "python(abi) = 3.7": 3
         }
       },
-      "python3-pillow-tk-5.3.0-1.fc30": {
+      "python3-pillow-tk-5.4.1-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -88780,25 +88751,10 @@
     "status": "idle"
   },
   "python-streamlink": {
-    "build_deps": [
-      "python-websocket-client",
-      "python2"
-    ],
-    "deps": [
-      "python-backports-shutil_get_terminal_size",
-      "python-backports-shutil_which",
-      "python-crypto",
-      "python-futures",
-      "python-iso-639",
-      "python-iso3166",
-      "python-isodate",
-      "python-pysocks",
-      "python-requests",
-      "python-singledispatch",
-      "python2"
-    ],
+    "build_deps": [],
+    "deps": [],
     "rpms": {
-      "python-streamlink-doc-0.14.2-3.fc29": {
+      "python-streamlink-doc-0.14.2-4.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -88807,18 +88763,7 @@
         },
         "py_deps": {}
       },
-      "python2-streamlink-0.14.2-3.fc29": {
-        "almost_leaf": true,
-        "legacy_leaf": true,
-        "non_python_requirers": {
-          "build_time": [],
-          "run_time": []
-        },
-        "py_deps": {
-          "python(abi) = 2.7": 2
-        }
-      },
-      "python3-streamlink-0.14.2-3.fc29": {
+      "python3-streamlink-0.14.2-4.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -88831,7 +88776,7 @@
         }
       }
     },
-    "status": "legacy-leaf"
+    "status": "released"
   },
   "python-structlog": {
     "build_deps": [],
@@ -88852,27 +88797,10 @@
     "status": "released"
   },
   "python-stuf": {
-    "build_deps": [
-      "python-setuptools",
-      "python2"
-    ],
-    "deps": [
-      "python-parse",
-      "python2"
-    ],
+    "build_deps": [],
+    "deps": [],
     "rpms": {
-      "python2-stuf-0.9.16-15.fc29": {
-        "almost_leaf": true,
-        "legacy_leaf": true,
-        "non_python_requirers": {
-          "build_time": [],
-          "run_time": []
-        },
-        "py_deps": {
-          "python(abi) = 2.7": 2
-        }
-      },
-      "python3-stuf-0.9.16-15.fc29": {
+      "python3-stuf-0.9.16-16.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -88884,7 +88812,7 @@
         }
       }
     },
-    "status": "legacy-leaf"
+    "status": "released"
   },
   "python-subliminal": {
     "build_deps": [
@@ -91713,6 +91641,25 @@
     "tracking_bugs": [
       "https://bugzilla.redhat.com/show_bug.cgi?id=1312032"
     ]
+  },
+  "python-tvb-gdist": {
+    "build_deps": [],
+    "deps": [],
+    "rpms": {
+      "python3-tvb-gdist-1.5.6-3.fc30": {
+        "almost_leaf": false,
+        "legacy_leaf": false,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {
+          "libpython3.7m.so.1.0()(64bit)": 3,
+          "python(abi) = 3.7": 3
+        }
+      }
+    },
+    "status": "released"
   },
   "python-tw-forms": {
     "build_deps": [
@@ -97538,7 +97485,6 @@
             "coan",
             "colobot",
             "graphite2",
-            "heimdal",
             "htop",
             "hyperscan",
             "json4s",
@@ -97597,6 +97543,7 @@
             "gstreamer",
             "gstreamer1",
             "guitarix",
+            "heimdal",
             "icu",
             "inn",
             "ispc",
@@ -97750,7 +97697,6 @@
             "sratom",
             "sugar-colordeducto",
             "sugar-flip",
-            "sugar-story",
             "sugar-xoeditor",
             "sundials",
             "sunpinyin",
@@ -97851,7 +97797,6 @@
       "gr-air-modes",
       "grass",
       "gstreamer-plugins-good",
-      "heimdal",
       "htop",
       "hyperscan",
       "json4s",
@@ -98357,26 +98302,6 @@
           "libpython3.7m.so.1.0()(64bit)": 3,
           "python3": 3,
           "python3 = 3.7.2-1.fc30": 3
-        }
-      }
-    },
-    "status": "released"
-  },
-  "python3-bsddb3": {
-    "build_deps": [],
-    "deps": [],
-    "rpms": {
-      "python3-bsddb3-6.2.6-2.fc29": {
-        "almost_leaf": false,
-        "legacy_leaf": false,
-        "non_python_requirers": {
-          "build_time": [],
-          "run_time": []
-        },
-        "py_deps": {
-          "/usr/bin/python3": 3,
-          "libpython3.7m.so.1.0()(64bit)": 3,
-          "python(abi) = 3.7": 3
         }
       }
     },
@@ -99311,7 +99236,7 @@
       "bug": [
         "https://bugzilla.redhat.com/show_bug.cgi?id=1585743",
         "NEW",
-        "2019-01-06 14:09:49"
+        "2019-01-09 10:55:54"
       ]
     },
     "note": "There is a problem in Fedora packaging, not necessarily with the software itself. See the linked Fedora bug.",
@@ -99544,7 +99469,7 @@
       "python2"
     ],
     "rpms": {
-      "python-qpid-proton-docs-0.24.0-4.fc29": {
+      "python-qpid-proton-docs-0.26.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -99553,7 +99478,7 @@
         },
         "py_deps": {}
       },
-      "python2-qpid-proton-0.24.0-4.fc29": {
+      "python2-qpid-proton-0.26.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -99567,7 +99492,7 @@
           "python2 = 2.7.15-10.fc30": 2
         }
       },
-      "python3-qpid-proton-0.24.0-4.fc29": {
+      "python3-qpid-proton-0.26.0-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -99576,7 +99501,6 @@
         },
         "py_deps": {
           "libpython3.7m.so.1.0()(64bit)": 3,
-          "libpython3.so()(64bit)": 3,
           "python(abi) = 3.7": 3,
           "python3": 3,
           "python3 = 3.7.2-1.fc30": 3
@@ -101752,7 +101676,7 @@
     "build_deps": [],
     "deps": [],
     "rpms": {
-      "rust-cbindgen-devel-0.6.7-1.fc30": {
+      "rust-cbindgen-devel-0.6.8-1.fc30": {
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
@@ -103381,31 +103305,6 @@
     },
     "status": "released"
   },
-  "singularity": {
-    "build_deps": [],
-    "deps": [],
-    "links": {
-      "bug": [
-        "https://bugzilla.redhat.com/show_bug.cgi?id=1452572",
-        "CLOSED ERRATA",
-        "2018-06-16 20:15:48"
-      ]
-    },
-    "rpms": {
-      "singularity-runtime-2.6.1-1.1.fc30": {
-        "almost_leaf": false,
-        "legacy_leaf": false,
-        "non_python_requirers": {
-          "build_time": [],
-          "run_time": []
-        },
-        "py_deps": {
-          "/usr/bin/python3": 3
-        }
-      }
-    },
-    "status": "released"
-  },
   "sip": {
     "build_deps": [
       "python2"
@@ -104849,7 +104748,6 @@
           "run_time": [
             "sugar-colordeducto",
             "sugar-flip",
-            "sugar-story",
             "sugar-xoeditor",
             "sugar-yupana"
           ]
@@ -105255,7 +105153,7 @@
       "sugar-toolkit-gtk3"
     ],
     "rpms": {
-      "sugar-getiabooks-17-4.fc29": {
+      "sugar-getiabooks-18.1-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105302,7 +105200,7 @@
       "sugar"
     ],
     "rpms": {
-      "sugar-imageviewer-63-5.fc29": {
+      "sugar-imageviewer-64-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105326,7 +105224,7 @@
       "sugar"
     ],
     "rpms": {
-      "sugar-implode-18-4.fc29": {
+      "sugar-implode-19-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105371,7 +105269,7 @@
       "sugar"
     ],
     "rpms": {
-      "sugar-jukebox-33-5.fc29": {
+      "sugar-jukebox-34-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105465,7 +105363,7 @@
       "sugar"
     ],
     "rpms": {
-      "sugar-log-38-5.fc29": {
+      "sugar-log-39-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105489,7 +105387,7 @@
       "sugar"
     ],
     "rpms": {
-      "sugar-maze-27-4.fc29": {
+      "sugar-maze-28-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105512,7 +105410,7 @@
       "sugar"
     ],
     "rpms": {
-      "sugar-measure-101-5.fc29": {
+      "sugar-measure-102-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105536,7 +105434,7 @@
       "sugar"
     ],
     "rpms": {
-      "sugar-memorize-54-2.fc29": {
+      "sugar-memorize-55-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105606,7 +105504,7 @@
       "sugar"
     ],
     "rpms": {
-      "sugar-paint-66-4.fc29": {
+      "sugar-paint-68-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105624,7 +105522,6 @@
   },
   "sugar-physics": {
     "build_deps": [
-      "python2",
       "sugar-toolkit-gtk3"
     ],
     "deps": [
@@ -105634,7 +105531,7 @@
       "sugar"
     ],
     "rpms": {
-      "sugar-physics-33-2.fc29": {
+      "sugar-physics-34-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105791,15 +105688,13 @@
     "status": "idle"
   },
   "sugar-record": {
-    "build_deps": [
-      "python2"
-    ],
+    "build_deps": [],
     "deps": [
       "sugar",
       "sugar-toolkit-gtk3"
     ],
     "rpms": {
-      "sugar-record-200-2.fc29": {
+      "sugar-record-200.2-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105867,7 +105762,7 @@
       "sugar-toolkit-gtk3"
     ],
     "rpms": {
-      "sugar-speak-54-6.fc29": {
+      "sugar-speak-57-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105939,7 +105834,31 @@
       "sugar"
     ],
     "rpms": {
-      "sugar-stopwatch-20-2.fc29": {
+      "sugar-stopwatch-20.1-1.fc30": {
+        "almost_leaf": true,
+        "legacy_leaf": true,
+        "non_python_requirers": {
+          "build_time": [],
+          "run_time": []
+        },
+        "py_deps": {
+          "/usr/bin/python2": 2
+        }
+      }
+    },
+    "status": "idle"
+  },
+  "sugar-story": {
+    "build_deps": [
+      "python2",
+      "sugar-toolkit-gtk3"
+    ],
+    "deps": [
+      "sugar",
+      "sugar-toolkit-gtk3"
+    ],
+    "rpms": {
+      "sugar-story-19-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -105963,7 +105882,7 @@
       "sugar"
     ],
     "rpms": {
-      "sugar-terminal-45.3-1.fc30": {
+      "sugar-terminal-45.4-1.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -106033,13 +105952,10 @@
           "build_time": [
             "sugar-colordeducto",
             "sugar-flip",
-            "sugar-story",
             "sugar-xoeditor",
             "sugar-yupana"
           ],
-          "run_time": [
-            "sugar-story"
-          ]
+          "run_time": []
         },
         "py_deps": {
           "/usr/bin/python2": 2,
@@ -106153,7 +106069,7 @@
       "sugar"
     ],
     "rpms": {
-      "sugar-words-23-2.fc29": {
+      "sugar-words-23-3.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -106890,7 +106806,7 @@
     ],
     "deps": [],
     "rpms": {
-      "syslog-ng-devel-3.18.1-1.fc30": {
+      "syslog-ng-devel-3.18.1-2.fc30": {
         "almost_leaf": true,
         "legacy_leaf": true,
         "non_python_requirers": {
@@ -114379,34 +114295,6 @@
         },
         "py_deps": {
           "/usr/bin/python2": 2,
-          "python(abi) = 2.7": 2
-        }
-      }
-    },
-    "status": "idle"
-  },
-  "zbar": {
-    "build_deps": [
-      "gtk2",
-      "pygtk2",
-      "python2"
-    ],
-    "deps": [
-      "pygtk2",
-      "python-pillow",
-      "python2"
-    ],
-    "rpms": {
-      "zbar-pygtk-0.20.1-3.fc29": {
-        "almost_leaf": true,
-        "legacy_leaf": true,
-        "non_python_requirers": {
-          "build_time": [],
-          "run_time": []
-        },
-        "py_deps": {
-          "pygtk2": 2,
-          "pygtk2 = 2.24.0-23.fc29": 2,
           "python(abi) = 2.7": 2
         }
       }


### PR DESCRIPTION
**idle** → **missing** (3)
- gst-inspector
- kcbench-data
- zbar

**legacy-leaf** → **released** (2)
- python-streamlink
- python-stuf

**mispackaged** → **idle** (1)
- python-muranoclient

**missing** → **idle** (1)
- sugar-story (FTBFS fix, python2 dep is not actually new)

**missing** → **released** (2)
- python-bsddb3
- python-tvb-gdist

**released** → **legacy-leaf** (3)
- python-iso-639
- python-iso3166
- python-parse

**released** → **missing** (2)
- python3-bsddb3
- singularity

## Naming status changes

**named correctly** → **missing** (5)
- gst-inspector
- kcbench-data
- python3-bsddb3
- singularity
- zbar

**requires misnamed** → **missing** (1)
- heimdal

---

No history update – the script picks up the first commit each day, which had no change.
