### PR TITLE
Mark Fedora 30 as current to display Mass Rebuild FTBFS

### DIFF
--- a/portingdb/load_data.py
+++ b/portingdb/load_data.py
@@ -17,7 +17,7 @@ DONE_STATUSES = PY2_STATUSES | {'dropped'}
 
 # Current Fedora version, used to get info about long-term FTBFSs
 # Update to the Rawhide version after a mass rebuild.
-CURRENT_FEDORA = 29
+CURRENT_FEDORA = 30
 
 try:
     SafeLoader = yaml.CSafeLoader


### PR DESCRIPTION
There's a lot of FTBFS markers … except in the py3-only packages. I think it is useful to have this.
@hroncok, please take a look (after your vacation) & let me know if it looks useful.