### PR TITLE
 Don't track dependencies on version-agnostic wheels

### DIFF
--- a/data/fedora.json
+++ b/data/fedora.json
@@ -6903,9 +6903,7 @@
     "status": "py3-only"
   },
   "copr-rpmbuild": {
-    "build_deps": [
-      "python-rpm-macros"
-    ],
+    "build_deps": [],
     "deps": [],
     "rpms": {
       "copr-rpmbuild-0.29-1.fc31": {
@@ -18359,9 +18357,7 @@
     "status": "py3-only"
   },
   "imagefactory": {
-    "build_deps": [
-      "python-rpm-macros"
-    ],
+    "build_deps": [],
     "deps": [],
     "rpms": {
       "imagefactory-1.1.13-0.20190527193658gita117084.fc31": {
@@ -18381,9 +18377,7 @@
     "status": "py3-only"
   },
   "imagefactory-plugins": {
-    "build_deps": [
-      "python-rpm-macros"
-    ],
+    "build_deps": [],
     "deps": [
       "euca2ools"
     ],
@@ -19314,9 +19308,7 @@
     "status": "idle"
   },
   "jpype": {
-    "build_deps": [
-      "python-rpm-macros"
-    ],
+    "build_deps": [],
     "deps": [],
     "rpms": {
       "python3-jpype-0.6.3-8.fc30": {
@@ -26018,9 +26010,7 @@
     "status": "py3-only"
   },
   "mlpack": {
-    "build_deps": [
-      "python-rpm-macros"
-    ],
+    "build_deps": [],
     "deps": [],
     "rpms": {
       "mlpack-python3-3.0.4-3.fc31": {
@@ -31576,9 +31566,7 @@
   },
   "polymake": {
     "build_deps": [],
-    "deps": [
-      "python-jupyter-core"
-    ],
+    "deps": [],
     "rpms": {
       "polymake-jupyter-0.16-3.fc31.1": {
         "almost_leaf": false,
@@ -37576,9 +37564,7 @@
     "status": "py3-only"
   },
   "python-aiosmtpd": {
-    "build_deps": [
-      "python-rpm-macros"
-    ],
+    "build_deps": [],
     "deps": [],
     "rpms": {
       "python3-aiosmtpd-1.2.1-2.fc30": {
@@ -38949,9 +38935,7 @@
     "status": "released"
   },
   "python-atpublic": {
-    "build_deps": [
-      "python-rpm-macros"
-    ],
+    "build_deps": [],
     "deps": [],
     "rpms": {
       "python3-atpublic-0.5-7.fc30": {
@@ -50836,9 +50820,7 @@
     "status": "py3-only"
   },
   "python-flufl-bounce": {
-    "build_deps": [
-      "python-rpm-macros"
-    ],
+    "build_deps": [],
     "deps": [],
     "rpms": {
       "python3-flufl-bounce-3.0-5.fc30": {
@@ -50856,9 +50838,7 @@
     "status": "py3-only"
   },
   "python-flufl-i18n": {
-    "build_deps": [
-      "python-rpm-macros"
-    ],
+    "build_deps": [],
     "deps": [],
     "rpms": {
       "python3-flufl-i18n-2.0.1-4.fc30": {
@@ -50876,9 +50856,7 @@
     "status": "py3-only"
   },
   "python-flufl-lock": {
-    "build_deps": [
-      "python-rpm-macros"
-    ],
+    "build_deps": [],
     "deps": [],
     "rpms": {
       "python3-flufl-lock-3.2-4.fc30": {
@@ -50896,9 +50874,7 @@
     "status": "py3-only"
   },
   "python-flufl-testing": {
-    "build_deps": [
-      "python-rpm-macros"
-    ],
+    "build_deps": [],
     "deps": [],
     "rpms": {
       "python3-flufl-testing-0.4-9.fc30": {
@@ -55500,9 +55476,7 @@
   },
   "python-ipykernel": {
     "build_deps": [],
-    "deps": [
-      "python-jupyter-core"
-    ],
+    "deps": [],
     "rpms": {
       "python-ipykernel-doc-5.1.1-1.fc31": {
         "almost_leaf": false,
@@ -55529,9 +55503,7 @@
   },
   "python-ipyparallel": {
     "build_deps": [],
-    "deps": [
-      "python-jupyter-core"
-    ],
+    "deps": [],
     "rpms": {
       "python-ipyparallel-doc-6.2.4-1.fc31": {
         "almost_leaf": false,
@@ -55668,7 +55640,6 @@
   },
   "python-iso8601": {
     "build_deps": [
-      "python-rpm-macros",
       "python-setuptools",
       "python2"
     ],
@@ -56847,10 +56818,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [],
-          "run_time": [
-            "R-IRkernel",
-            "gap-pkg-jupyterkernel"
-          ]
+          "run_time": []
         },
         "py_deps": {}
       },
@@ -59854,9 +59822,7 @@
   },
   "python-metakernel": {
     "build_deps": [],
-    "deps": [
-      "python-jupyter-core"
-    ],
+    "deps": [],
     "rpms": {
       "python-metakernel-doc-0.24.2-1.fc31": {
         "almost_leaf": false,
@@ -66700,24 +66666,8 @@
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
-          "build_time": [
-            "jython",
-            "pypy",
-            "pypy3",
-            "python34",
-            "python35",
-            "python36",
-            "python38"
-          ],
-          "run_time": [
-            "jython",
-            "pypy",
-            "pypy3",
-            "python34",
-            "python35",
-            "python36",
-            "python38"
-          ]
+          "build_time": [],
+          "run_time": []
         },
         "py_deps": {}
       },
@@ -75082,12 +75032,7 @@
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
-          "build_time": [
-            "backintime",
-            "ecryptfs-utils",
-            "python34",
-            "python35"
-          ],
+          "build_time": [],
           "run_time": []
         },
         "py_deps": {}
@@ -75097,9 +75042,7 @@
         "legacy_leaf": false,
         "non_python_requirers": {
           "build_time": [],
-          "run_time": [
-            "redhat-rpm-config"
-          ]
+          "run_time": []
         },
         "py_deps": {}
       },
@@ -76368,24 +76311,8 @@
         "almost_leaf": false,
         "legacy_leaf": false,
         "non_python_requirers": {
-          "build_time": [
-            "jython",
-            "pypy",
-            "pypy3",
-            "python34",
-            "python35",
-            "python36",
-            "python38"
-          ],
-          "run_time": [
-            "jython",
-            "pypy",
-            "pypy3",
-            "python34",
-            "python35",
-            "python36",
-            "python38"
-          ]
+          "build_time": [],
+          "run_time": []
         },
         "py_deps": {}
       },
@@ -83567,15 +83494,11 @@
   },
   "python-virtualenv": {
     "build_deps": [
-      "python-pip",
       "python-setuptools",
-      "python-wheel",
       "python2"
     ],
     "deps": [
-      "python-pip",
       "python-setuptools",
-      "python-wheel",
       "python2"
     ],
     "rpms": {
@@ -87095,12 +87018,8 @@
     "status": "py3-only"
   },
   "python2": {
-    "build_deps": [
-      "python-pip",
-      "python-setuptools"
-    ],
+    "build_deps": [],
     "deps": [
-      "python-pip",
       "python-rpm-macros",
       "python-setuptools"
     ],
@@ -87652,16 +87571,8 @@
     "status": "idle"
   },
   "python3": {
-    "build_deps": [
-      "python-pip",
-      "python-rpm-macros",
-      "python-setuptools"
-    ],
-    "deps": [
-      "python-pip",
-      "python-rpm-macros",
-      "python-setuptools"
-    ],
+    "build_deps": [],
+    "deps": [],
     "links": {
       "bug": [
         "https://bugzilla.redhat.com/show_bug.cgi?id=1322027",
@@ -89519,7 +89430,6 @@
   },
   "recoll": {
     "build_deps": [
-      "python-rpm-macros",
       "python-setuptools",
       "python2"
     ],
@@ -89529,8 +89439,8 @@
     "links": {
       "bug": [
         "https://bugzilla.redhat.com/show_bug.cgi?id=1546682",
-        "CLOSED NOTABUG",
-        "2018-09-30 16:54:58"
+        "NEW",
+        "2019-07-08 15:48:07"
       ]
     },
     "note": "A single package depends on both Python 2 and Python 3.\nIt should be split into a python2 and python3 subpackages to prevent it from always dragging the py2 dependency in.",
@@ -90255,7 +90165,6 @@
       "python2"
     ],
     "deps": [
-      "python-jupyter-core",
       "python2"
     ],
     "rpms": {
@@ -90920,8 +90829,7 @@
   "sagemath": {
     "build_deps": [],
     "deps": [
-      "Singular",
-      "python-jupyter-core"
+      "Singular"
     ],
     "rpms": {
       "sagemath-8.8-1.fc31": {

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -293,6 +293,11 @@ class Py3QueryCommand(dnf.cli.Command):
         for pkg in progressbar(sorted(python_versions.keys()), 'Getting requirements'):
             if python_versions[pkg] == {3}:
                 continue
+            if pkg.name in NAME_NOTS:
+                # "NAME_NOTS" are Python-version-agnostic packages,
+                # such as wheels, RPM macros and documentation.
+                # Don't track those as python2 dependencies.
+                continue
             reqs = set()
             build_reqs = set()
             for provide in pkg.provides:

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -337,7 +337,7 @@ class Py3QueryCommand(dnf.cli.Command):
                     requirer_srpm_name = get_srpm_name(pkg)
                     unversioned_requirers[requirement_srpm_name].add(requirer_srpm_name)
 
-        # deps_of_pkg: {srpm name: info}
+        # json_output: {srpm name: info}
         json_output = dict()
         for name in progressbar(by_srpm_name, 'Generating output'):
             pkgs = sorted(by_srpm_name[name])


### PR DESCRIPTION
Explicitly don't track dependencies on `python-pip-wheel`, `python-setuptools-wheel`, `python-wheel-wheel` – portingdb looked at these names and thought they might be old-style Python2 packages.
(Note that we only track python2 dependencies.)

This untangles some loops in the build dependency graph.

---
\+ 1 small unrelated fix