### PR TITLE
Improve dependency trees, rename statuses, clarify this is Rawhide

### DIFF
--- a/data/statuses.yaml
+++ b/data/statuses.yaml
@@ -51,7 +51,7 @@
 
     If this is a false positive, file a portingdb bug.
 - ident: idle
-  name: Idle
+  name: Not ported
   abbrev: I
   color: 'DDDDDD'
   term: ' '
@@ -81,7 +81,7 @@
     (Note that there might be false positives; if you spot one, please
     [file a bug](https://github.com/fedora-python/portingdb/issues))
 - ident: dropped
-  name: Dropped
+  name: Legacy
   abbrev: X
   color: '888888'
   term: X
@@ -89,8 +89,8 @@
   description: Package will not be ported; dependents must use an alternative
   rank: 1
   instructions: |
-    This package will not be ported to Python 3. We can do without it – see
-    if there is an alternative listed in the notes.
+    This package will not be ported to Python 3.
+    Usually there is an alternative listed in the notes.
 
     If you think it would be good to port it anyway, get in touch with the upstream!
 - ident: unknown

--- a/portingdb/static/style.css
+++ b/portingdb/static/style.css
@@ -74,6 +74,12 @@ nav, nav ol {
 .rpm-list li .rpm-name {
     font-weight: bold;
 }
+.deptree-level {
+    border-left: 1px solid #EEE;
+}
+.deptree-elided {
+    padding-left: 1em; line-height: 50%;
+}
 .iconlink-bug-NEW,
 .iconlink-bug-CLOSED-DEFERRED
     { color: #AAAAAA !important; } /* ~idle */

--- a/portingdb/templates/_base.html
+++ b/portingdb/templates/_base.html
@@ -32,16 +32,20 @@
     {% endif %}
 {%- endmacro %}
 
-{% macro pkglink(pkg, ignore_misnamed=False, ignore_unversioned_requires=False) -%}
-    {{ pkglink_icon(pkg) }}&nbsp;<a href="{{ url_for('package', pkg=pkg.name) }}">
+{% macro pkglink(
+    pkg, ignore_misnamed=False, ignore_unversioned_requires=False, after_name='')
+-%}
+    {{- pkglink_icon(pkg) -}}
+    &nbsp;<a href="{{ url_for('package', pkg=pkg.name) }}">
         {{- pkg.name -}}
-        {{- pkg_naming_badge(
-            pkg,
-            ignore_misnamed=ignore_misnamed,
-            ignore_unversioned_requires=ignore_unversioned_requires,
-        ) -}}
-        {{- ftbfs_badge(pkg) -}}
     </a>
+    {{- after_name -}}
+    {{- pkg_naming_badge(
+        pkg,
+        ignore_misnamed=ignore_misnamed,
+        ignore_unversioned_requires=ignore_unversioned_requires,
+    ) -}}
+    {{- ftbfs_badge(pkg) -}}
 {%- endmacro %}
 
 {% macro pkglink_icon(pkg) -%}
@@ -66,12 +70,12 @@
 {%- endmacro %}
 
 {% macro pkg_naming_badge(pkg, ignore_misnamed=False, ignore_unversioned_requires=False) -%}
-    {% if pkg['is_misnamed'] and not ignore_misnamed %}
+    {%- if pkg['is_misnamed'] and not ignore_misnamed %}
         {{ misnamed_badge() }}
-    {% endif %}
-    {% if pkg['unversioned_requires'] and not ignore_unversioned_requires %}
+    {% endif -%}
+    {%- if pkg['unversioned_requires'] and not ignore_unversioned_requires %}
         {{ unversioned_requires_badge( pkg['blocked_requires']) }}
-    {% endif %}
+    {% endif -%}
 {%- endmacro %}
 
 {% macro _naming_badge(color, text) -%}
@@ -94,24 +98,34 @@
     {%- endif -%}
 {%- endmacro %}
 
-{% macro print_deptree(pkgs) -%}
+{% macro print_deptree(nodes) -%}
     <ul class="simple-pkg-list">
-        {{ sub_deptree(pkgs) }}
+        {{ sub_deptree(nodes) }}
     </ul>
 {%- endmacro %}
 
-{% macro sub_deptree(pkgs) -%}
-    {% for pkg, kinds, subtree in pkgs %}
-        <li>
-            {{ pkglink(pkg) }}
-            {% if 'run' in kinds %}<i class="dep-kind fa fa-rocket"></i>{% endif %}
-            {% if 'build' in kinds %}<i class="dep-kind fa fa-wrench"></i>{% endif %}
-            {% if 'elided' in kinds %}…{% endif %}
-            <ul class="simple-pkg-list" style="border-left: 1px solid #EEE">
-                {{ sub_deptree(subtree) }}
-            </ul>
+{% macro sub_deptree(nodes) -%}
+    {%- for node in nodes -%}
+        <li title="{{node.path}}">
+            {{ pkglink(node.package, after_name=':' if node.children else '') }}
+            {% if 'run' in node.kinds -%}
+                <i class="dep-kind fa fa-rocket" title="Run-time"></i>
+            {%- endif -%}
+            {%- if 'build' in node.kinds %}
+                <i class="dep-kind fa fa-wrench" title="Build-time"></i>
+            {%- endif -%}
+            {%- if 'elided' in node.kinds -%}
+                <span title="Subtree elided"> ⋯</span>
+            {%- endif -%}
+            {%- if node.children -%}
+                <ul class="simple-pkg-list deptree-level">
+                    {{- sub_deptree(node.children) -}}
+                </ul>
+            {%- elif 'too-big' in node.kinds -%}
+                <div class="deptree-level deptree-elided" title="Subtree elided (graph too large)">⋯</div>
+            {%- endif -%}
         </li>
-    {% endfor %}
+    {%- endfor -%}
 {%- endmacro %}
 
 {% macro pkglist_table_head() -%}

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -81,7 +81,7 @@
                     </span>
                 </span>
                 <span class="stuffing">
-                    Python packages in {{ config['name'] }} support
+                    Python packages in Fedora Rawhide support
                 </span>
                 <span class="callout">Python 3 only.</span>
             </div>
@@ -96,7 +96,7 @@
                     </span>
                 </span>
                 <span class="stuffing">
-                    Python packages in {{ config['name'] }} support
+                    Python packages in Fedora Rawhide support
                 </span>
                 <span class="callout">Python 3.</span>
             </div>


### PR DESCRIPTION
I nerd-sniped myself a bit last week on portingdb, but ran out of time.
These patches aren't as polished as I'd like, but I won't have much time for them, so putting them up for review. Merge any you like.

The first patch should make dependency trees on the package & group pages useful for scoping FESCo exceptions.
