### PR TITLE
Update status of edk2

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -83,11 +83,6 @@ dtrx:
     dead-upstream: true
 dwarves:
     dead-upstream: true
-edk2:
-    status: idle
-    note: |
-        There's a python2 and a python3 subpackage, but they do different
-        things.
 epydoc:
     dead-upstream: true
 findthatword:


### PR DESCRIPTION
edk2 contains multiple python subpackages but all of them depends only on Python 3 so no matter what purpose they serve, this is Py3-only package.