### PR TITLE
New bugs

### DIFF
--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -32,6 +32,7 @@ BUGZILLA_URL = 'bugzilla.redhat.com'
 # Tracker bugs which are used to find all relevant package bugs
 TRACKER_BUGS = {
     1698500: "F31_PY2REMOVAL",
+    1625773: "PY2REMOVAL",
     1690439: "PY2FTBI",
     1312032: "PY3PATCH-AVAILABLE",
     1333770: "PY3PATCH-PUSH",

--- a/portingdb/cli.py
+++ b/portingdb/cli.py
@@ -65,40 +65,6 @@ def serve(ctx, debug, cache, port):
                     port=port)
 
 
-@cli.command('bugless-mispackaged')
-@click.pass_context
-def bugless_mispackaged(ctx):
-    """List mispackaged packages that do not have a BugZilla report yet.
-
-    Exits with error code 1 if such packages are found.
-
-    Use the --verbose flag to get the output pretty-printed for humans.
-    """
-    data = get_data(*ctx.obj['datadirs'])
-
-    results = []
-    for package in data['packages'].values():
-        if package['status'] == 'mispackaged':
-            if not any(link['type'] == 'bug' for link in package['links']):
-                results.append(package)
-
-    if ctx.obj['verbose'] > 0:
-        if results:
-            print("\nThe following packages are both 'mispackaged' and "
-                    "do not have an associated Bugzilla report:\n")
-            for p in results:
-                print("\t{}".format(p['name']))
-            print()
-        else:
-            print("\nThere are no packages both 'mispackaged' and "
-                    "not having an associated Bugzilla report.\n")
-    else:
-        for p in results:
-            print("{}".format(p['name']))
-
-    if results:
-        exit(1)
-
 @cli.command('closed-mispackaged')
 @click.pass_context
 def closed_mispackaged(ctx):

--- a/portingdb/load_data.py
+++ b/portingdb/load_data.py
@@ -150,6 +150,7 @@ def load_from_directories(data, directories):
         package.setdefault('build_dependents', {})
         package.setdefault('groups', {})
         package.setdefault('tracking_bugs', ())
+        package.setdefault('bugs', {})
         package.setdefault('last_link_update', None)
         package.setdefault('unversioned_requires', {})
         package.setdefault('blocked_requires', {})
@@ -193,7 +194,7 @@ def load_from_directories(data, directories):
     for name, package in packages.items():
         package['status_obj'] = statuses.get(package['status'])
 
-    # Convert bug info
+    # Convert link info
     for name, package in packages.items():
         links = []
         link_updates = []
@@ -306,6 +307,18 @@ def load_from_directories(data, directories):
             package['ftbfs_age'] = max(CURRENT_FEDORA - releasever, 0)
         else:
             package['ftbfs_age'] = 0
+
+    # Postprocess bugs
+    # - Add bug ID to the bug's info dict
+    # - Convert last_change to datetime
+    for name, package in packages.items():
+        for id, bug in package['bugs'].items():
+            bug['id'] = id
+            if bug['last_change']:
+                last_change = datetime.datetime.strptime(
+                    bug['last_change'], '%Y-%m-%d %H:%M:%S',
+                )
+                bug['last_change'] = last_change
 
     # Consolidate non-Python requirers
     for name, package in packages.items():

--- a/portingdb/templates/_base.html
+++ b/portingdb/templates/_base.html
@@ -166,12 +166,6 @@
 {% macro iconlink_class(link) -%}
     {% if link.type == 'repo' %}
         iconlink fa fa-code
-    {% elif link.type == 'bug' %}
-        iconlink fa fa-bug
-        {% if link.note %}
-            iconlink-bug-{{ link.note.partition(' ')[0] }}
-            iconlink-bug-{{ link.note | replace(' ', '-') }}
-        {% endif %}
     {% elif link.type == 'homepage' %}
         iconlink fa fa-home
     {% endif %}
@@ -183,6 +177,16 @@
         {{" "}}({{ link.note }})
     {%- endif -%}
 {%- endmacro %}
+
+{% macro bugicon(bug, extra_class='') %}
+    <i class="iconlink fa fa-bug {{ extra_class }} iconlink-bug-{{ bug.status }}
+    {% if bug.resolution %}iconlink-bug-{{ bug.status }}-{{ bug.resolution }}{% endif %}
+    "
+    title="{{ bug.short_desc }} ({{ bug.status }}
+            {%- if bug.resolution %} {{ bug.resolution }}{% endif -%}
+            ; updated {{ bug.last_change.date() }})">
+    </i>
+{% endmacro %}
 
 {% macro iconlink(link) -%}
     <a href="{{ link.url }}" title="{{ iconlink_alt(link) }}" class="{{ iconlink_class(link) }}">

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -188,29 +188,13 @@
                 <div>
                     {{ len(mispackaged_packages) }} packages were found to have some kind of packaging problem.
                 </div>
-                <table class="table table-striped table-condensed table-hovered">
-                    <tr>
-                        <th>Package</th>
-                        <th>Last Bugzilla activity</th>
-                    </tr>
-
-                    {% for pkg in mispackaged_packages %}
-                    <tr>
-                        <td>
-                            {{ pkglink(pkg) }}
-                        </td>
-                        <td>
-                            {% if pkg.last_link_update %}
-                                <time title="{{ pkg.last_link_update }}">
-                                    {{ pkg.last_link_update | format_time_ago }}
-                                </time>
-                            {% else %}
-                                no Bugzilla report yet
-                            {% endif %}
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </table>
+                <ul class="simple-pkg-list">
+                {% for pkg in mispackaged_packages %}
+                    <li>
+                        <div title="{{ pkg.note }}">{{ pkglink(pkg) }}</div>
+                    </li>
+                {% endfor %}
+                </ul>
 
             {% endif %}
             <h2 id="idle">Idle packages</h2>

--- a/portingdb/templates/package.html
+++ b/portingdb/templates/package.html
@@ -53,6 +53,19 @@
     {% endif %}
 {% endmacro %}
 
+{% macro buglink(bug) %}
+    <a href="{{ bug.url }}">#{{ bug.id }} {{ bug.short_desc }}</a>
+    {% if bug.trackers %}
+        <small>
+            (for {% for tracker in bug.trackers | sort -%}
+                <a href="https://bugzilla.redhat.com/show_bug.cgi?id={{ tracker }}"
+                >{{ tracker }}</a>
+                {%- if not loop.last %}, {% endif -%}
+            {% endfor %})
+        </small>
+    {% endif %}
+{% endmacro %}
+
 {% block bodycontent %}
     <div class="container">
         <div class="col-md-12">
@@ -106,6 +119,33 @@
             </div>
         </div>
         <div class="col-md-3">
+                {% if pkg['bugs'] %}
+                    <div>
+                        <h3>Bugs</h3>
+                        <ul class="pkg-link-list fa-ul">
+                            {% for id, bug in pkg['bugs'].items() %}
+                                <li>
+                                    {{ bugicon(bug, 'fa-li') }}
+                                    {{ buglink(bug) }}
+                                    <div>
+                                        <small>
+                                            {{ bug.status }}
+                                            {{ bug.resolution }}
+                                        </small>
+                                    </div>
+                                    <div>
+                                        <small>
+                                            Updated
+                                            <span title="{{ bug.last_change }}">
+                                                {{ bug.last_change.date() }}
+                                            </span>
+                                        </small>
+                                    </div>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                {% endif %}
                 {% set pc = pkg %}
                 {% if pc %}
                     {% if 'note' in pc %}


### PR DESCRIPTION
Remember the time I nerd-sniped myself on portingdb?
This is probably the last usable thing from that.

When portingdb started, it collected "links" for upstream URL, the py3 porting bug, Bugzillas, etc.
These are now usually unused – we don't want to store information in portingdb if we can avoid it.

This pulls bugs out of links, makes it possible to add more of them, tracks the trackers, and displays them on the package page:

![image](https://user-images.githubusercontent.com/302922/63278082-e68ef900-c2a6-11e9-92d5-37237f63feb8.png)
