### PR TITLE
cairo-dock-plug-ins is fixed in rawhide

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -8,11 +8,6 @@ gtk2: &devel-only
 
 # Maintainer ignores mass removal
 
-cairo-dock-plug-ins:
-    status: dropped
-    note: |
-      Maintainer ignores the Mass Python 2 Package Removal change,
-      see [BZ#1629818](https://bugzilla.redhat.com/show_bug.cgi?id=1629818).
 python-mecab:
     status: dropped
     note: |


### PR DESCRIPTION
https://koji.fedoraproject.org/koji/buildinfo?buildID=1361142