### PR TITLE
Adjust for python27, python2-{pip,setuptools}

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -171,10 +171,10 @@ pygtksourceview:
       [gtksourceview](https://src.fedoraproject.org/rpms/gtksourceview/)
       uses GObject introspection, it has no own Python code and thus does not
       show up in PortingDB.
-python2:
+python27:
     status: dropped
     note: |
-      This is the Python 2 package.
+      This is the Python 2.7 package.
       Please port to Python 3.
 python-backports:
     status: dropped

--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -272,6 +272,11 @@ python-pathlib:
   note: |
     This is a backport of `pathlib`, part of the Python 3.4
     standard library.
+python2-pip:
+  status: dropped
+  note: |
+    This is the Python 2 version.
+    The `python-pip` package provides `python3-pip`.
 python2-pluggy:
     status: dropped
     note: |
@@ -294,6 +299,11 @@ python-qpid:
   note: |
     Only `qpid-cpp` depends on `python-qpid`, and `python-qpid` depends
     back on `qpid-cpp`.
+python2-setuptools:
+  status: dropped
+  note: |
+    This is the Python 2 version.
+    The `python-setuptools` package provides `python3-setuptools`.
 python-subprocess32:
     status: dropped
     note: |

--- a/dnf-plugins/py3query.py
+++ b/dnf-plugins/py3query.py
@@ -51,7 +51,7 @@ BUGZILLA_BUG_URL = "https://bugzilla.redhat.com/show_bug.cgi?id={}"
 SEED_PACKAGES = {
     2: [
         'python2-devel', 'python2', 'python2-libs', 'python2-tkinter',
-        'python(abi) = 2.7', '/usr/bin/python2',
+        'python(abi) = 2.7', '/usr/bin/python2', 'python27',
         '/usr/bin/python2.7', 'libpython2.7.so.1.0', 'libpython2.7.so.1.0()(64bit)',
         'pygtk2', 'pygobject2', 'pycairo',
     ],
@@ -267,6 +267,11 @@ class Py3QueryCommand(dnf.cli.Command):
                         continue
                     if pkg not in python_versions:
                         python_versions[pkg].add(version)
+
+        # add python27 package manually, it doesn't require Python 2, but it is
+        query = self.pkg_query.filter(name='python27')
+        for pkg in query:
+            python_versions[pkg].add(2)
 
         # srpm_names: {package: srpm name}
         # by_srpm_name: {srpm name: set of packages}


### PR DESCRIPTION
python27 still doesn't show up, but I have only retired python2 just now and I suppose ti might be interfering it somehow.