### PR TITLE
Update VTE info

### DIFF
--- a/data/fedora-update.yaml
+++ b/data/fedora-update.yaml
@@ -318,8 +318,8 @@ texlive-base:
 vte:
   status: dropped
   note: |
-    Replacement: [`vte3`](https://src.fedoraproject.org/rpms/vte3/)
-    (Note that [vte3](https://src.fedoraproject.org/rpms/vte3/) does
+    Replacement: [`vte291`](https://src.fedoraproject.org/rpms/vte291/)
+    (Note that [vte291](https://src.fedoraproject.org/rpms/vte291/) does
     not itself depend on Python, so it does not show up in portingdb).
 will-crash:
     status: released  # (exception)


### PR DESCRIPTION
vte3 in retired in rawhide, the latest version of this software is in vte291 package.