### PR TITLE
⏻ Add "orphaned" badges to package names

### DIFF
--- a/portingdb/templates/_base.html
+++ b/portingdb/templates/_base.html
@@ -46,7 +46,16 @@
         ignore_unversioned_requires=ignore_unversioned_requires,
     ) -}}
     {{- ftbfs_badge(pkg) -}}
+    {{- orphan_badge(pkg) -}}
 {%- endmacro %}
+
+{% macro orphan_badge(pkg) -%}
+    {%- if 'orphan' in pkg['maintainers'] -%}
+        <sup>
+            <i class="fa fa-power-off" title="The package is orphaned."></i>
+        </sup>
+    {%- endif -%}
+{%- endmacro -%}
 
 {% macro pkglink_icon(pkg) -%}
     <span class="pkgstatus-icon" style="background-color: {{ pkg.status_obj.color }}">&nbsp;</span>

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -212,8 +212,11 @@
                         {{ pkglink(pkg) }}
                         {% if pkg.pending_dependents %}
                            (needed for
-                               {% for req in pkg.pending_dependents.values() %}
-                                   {{ pkglink_text(req) }}{% if not loop.last %},{% endif %}{% endfor %})
+                                {% for req in pkg.pending_dependents.values() -%}
+                                   {{- pkglink_text(req) -}}
+                                   {{- orphan_badge(req) -}}
+                                   {%- if not loop.last %}, {% endif -%}
+                                {%- endfor -%})
                         {% endif %}
                    </li>
                 {% endfor %}
@@ -231,8 +234,11 @@
                         {{ pkglink(pkg) }}
                         {% if pkg.pending_deps %}
                            (needs
-                               {% for req in pkg.pending_deps.values() %}
-                                   {{ pkglink_text(req) }}{% if not loop.last %},{% endif %}{% endfor %})
+                               {% for req in pkg.pending_deps.values() -%}
+                                   {{- pkglink_text(req) -}}
+                                   {{- orphan_badge(req) -}}
+                                   {%- if not loop.last %}, {% endif -%}
+                                {%- endfor -%})
                         {% endif %}
                    </li>
                {% endfor %}

--- a/portingdb/templates/package.html
+++ b/portingdb/templates/package.html
@@ -100,6 +100,16 @@
                 {% endif %}
                 <br>
             {% endif %}
+            {%- if 'orphan' in pkg['maintainers'] -%}
+                <div>
+                    <i class="fa fa-power-off" title="The package is orphaned."></i>
+                    This package is
+                    <a href="https://fedoraproject.org/wiki/Orphaned_package_that_need_new_maintainers">orphaned</a>.
+                    It will be removed from Fedora if no one steps up to
+                    maintain it.
+                </div>
+                <br>
+            {%- endif -%}
             {% if pkg.ftbfs_age %}
                 <div>
                     {{ ftbfs_badge(pkg) }}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/302922/66114245-ba1d0b00-e5ce-11e9-9c4c-112560497019.png)

I also had some code to show how long these were orphaned, but it takes too long to update (by querying pagure).