### PR TITLE
Track new approved FESCo exceptions for autodownloader and mozjs60

### DIFF
--- a/data/groups.yaml
+++ b/data/groups.yaml
@@ -144,6 +144,16 @@ texlive:
     exception: https://pagure.io/fesco/issue/2215
     packages:
     - texlive-base
+autodownloader:
+    name: autodownloader
+    exception: https://pagure.io/fesco/issue/2248
+    packages:
+    - autodownloader
+mozjs60:
+    name: mozjs60
+    exception: https://pagure.io/fesco/issue/2249
+    packages:
+    - mozjs60
 gnuradio:
     name: GNU Radio
     hidden: true


### PR DESCRIPTION
autodownloader: https://pagure.io/fesco/issue/2248
mozjs60: https://pagure.io/fesco/issue/2249