### PR TITLE
Remove Mercurial extras, there is no exc. request

### DIFF
--- a/data/groups.yaml
+++ b/data/groups.yaml
@@ -222,16 +222,6 @@ mercurial:
     exception: https://pagure.io/fesco/issue/2243
     packages:
     - mercurial
-mercurial-extras:
-    name: Mercurial extras
-    hidden: true
-    packages:
-    - git-cinnabar
-    - git-remote-hg
-    - hg-git
-    - hgview
-    - tortoisehg
-    - trac-mercurial-plugin
 git-cinnabar:
     name: Git Cinnabar
     exception: https://pagure.io/fesco/issue/2271


### PR DESCRIPTION

This is the last group without exception (request), so remove it, to avoid confusion.