### PR TITLE
Remove naming policy tracking

### DIFF
--- a/docs/update_portingdb.rst
+++ b/docs/update_portingdb.rst
@@ -53,7 +53,6 @@ The following steps are needed to update pordingdb data:
 #. Get historical status and naming policy data and update ``history.csv`` and ``history-naming.csv``::
 
     (venv) $ python -u scripts/get-history.py --update data/history.csv | tee history.csv && mv history.csv data/history.csv
-    (venv) $ python -u scripts/get-history.py -n --update data/history-naming.csv | tee history-naming.csv && mv history-naming.csv data/history-naming.csv
 
 #. Update the maintainer and orphans lists::
 

--- a/portingdb/templates/index.html
+++ b/portingdb/templates/index.html
@@ -330,20 +330,6 @@
                 Individual package pages list the RPM
                 versions this report is based on.
             </div>
-            <h2><a href="{{url_for('namingpolicy') }}">Naming Policy</a></h2>
-            <div>Tracking packages which do not comply with <a href="https://fedoraproject.org/wiki/Packaging:Naming?rd=Packaging:NamingGuidelines#Python_source_package_naming" target="_blank">Python package naming guidelines</a></div>
-            <ul class="list-group">
-                {% for status, count in naming_progress %}
-                <li class="list-group-item">
-                    {% if status.ident != 'name-correct' %}<a href="{{url_for('namingpolicy') }}#{{ status.ident }}">{% endif %}
-                    {{ count }}
-                    {{ naming_status_badge(status) }}
-                    <strong>{{ status.name }}</strong>
-                    {% if status.ident != 'name-correct' %}</a>{% endif %}
-                    <div><small>{{ status.short_description }}</small></div>
-                </li>
-                {% endfor %}
-            </ul>
             {% if 'extra-sidebar' in config %}
                 {{ config['extra-sidebar'] |safe }}
             {% endif %}

--- a/scripts/jsondiff.py
+++ b/scripts/jsondiff.py
@@ -7,12 +7,6 @@ import blessings
 import click
 
 
-def has_misnamed(rpms):
-    for rpm in rpms:
-        if rpms[rpm].get('is_misnamed'):
-            return True
-
-
 def compare_statuses(first, second):
     first_status = first.get('status', 'missing')
     second_status = second.get('status', 'missing')
@@ -21,65 +15,10 @@ def compare_statuses(first, second):
         return first_status, second_status
 
 
-def compare_naming_statuses(first, second):
-    first_rpms = first.get('rpms', {})
-    second_rpms = second.get('rpms', {})
-
-    def _name_status(rpms):
-        if not rpms:
-            return 'missing'
-        if has_misnamed(rpms):
-            return 'misnamed'
-        return 'named correctly'
-
-    first_misnamed = _name_status(first_rpms)
-    second_misnamed = _name_status(second_rpms)
-
-    if (first_misnamed != second_misnamed and
-            # No need to report those, they're fine.
-            (first_misnamed, second_misnamed) !=
-            ('missing', 'named correctly')):
-        return first_misnamed, second_misnamed
-
-
-def set_requires_state(package, packages_data, requires):
-    for pkg in package.get('unversioned_requirers', []):
-        require = packages_data.get(pkg, {})
-        if not has_misnamed(require.get('rpms', {})):
-            status = requires.setdefault(pkg, 'requires misnamed')
-            if status != 'requires blocked':
-                if has_misnamed(package.get('rpms', {})):
-                    requires[pkg] = 'requires blocked'
-
-
-def compare_requires(first_requires, second_requires,
-                     first_data, second_data):
-    changes = {}
-    for key, first_state in first_requires.items():
-        try:
-            second_state = second_requires.pop(key)
-        except KeyError as err:
-            second_state = 'requires ok' if second_data.get(key) else 'missing'
-        if first_state != second_state:
-            change = (first_state, second_state)
-            changes.setdefault(change, []).append(key)
-
-    for key, second_state in second_requires.items():
-        first_state = 'requires ok' if first_data.get(key) else 'missing'
-        change = (first_state, second_state)
-        changes.setdefault(change, []).append(key)
-
-    return changes
-
-
 def compare_files(first_data, second_data):
     all_keys = set(first_data).union(second_data)
 
     status_changes = {}
-    naming_status_changes = {}
-
-    first_requires = {}
-    second_requires = {}
 
     for key in sorted(all_keys):
         first = first_data.get(key, {})
@@ -89,19 +28,7 @@ def compare_files(first_data, second_data):
         if change:
             status_changes.setdefault(change, []).append(key)
 
-        change = compare_naming_statuses(first, second)
-        if change:
-            naming_status_changes.setdefault(change, []).append(key)
-
-        set_requires_state(first, first_data, first_requires)
-        set_requires_state(second, second_data, second_requires)
-
-    naming_status_changes.update(
-        compare_requires(
-            first_requires, second_requires,
-            first_data, second_data))
-
-    return status_changes, naming_status_changes
+    return status_changes
 
 
 @click.command(help=__doc__)
@@ -116,8 +43,7 @@ def main(first_filename, second_filename):
     with open(second_filename) as f:
         second_data = json.load(f)
 
-    status_changes, naming_status_changes = compare_files(
-        first_data, second_data)
+    status_changes = compare_files(first_data, second_data)
 
     # Print changes.
     print(term.green('Update Fedora data'))
@@ -136,16 +62,6 @@ def main(first_filename, second_filename):
         print(term.blue('**{}** → **{}** ({}) {}'.format(
             *change, len(packages), badge_marker,
         )))
-        for package in packages:
-            print('-', package)
-        print()
-
-    print(term.green('Naming status changes'))
-    print(term.green('---------------------'))
-    print()
-
-    for change, packages in sorted(naming_status_changes.items()):
-        print(term.blue('**{}** → **{}** ({})'.format(*change, len(packages))))
         for package in packages:
             print('-', package)
         print()


### PR DESCRIPTION
Naming is done; the one remaining package is a false positive (python-imgcreate-sysdeps is a metapackage).

The URLs still work, but not linked to; naming history is no longer updated or reported in jsondiff.