### PR TITLE
Remove or or embed functions from taskotron-python-versions

### DIFF
--- a/docs/update_portingdb.rst
+++ b/docs/update_portingdb.rst
@@ -11,7 +11,6 @@ To use the portingdb update scripts, you will need to install and configure the 
 #. Install system-wide dependencies::
 
     $ sudo dnf install python3-bugzilla python3-libarchive-c
-    $ /usr/bin/python3 -m pip install --user taskotron-python-versions
 
    Note that you cannot use Python virtual environments for this.
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ requires = [
     'click >= 7.0, < 8.0',
     'flask >= 1.0, < 2.0',
     'markdown >= 3.0, < 4.0',
-    'taskotron-python-versions >= 0.1.dev6',
     'plotly >= 3.0, < 4.0',
     'blessings >= 1.7, < 2.0',
     'elsa >= 0.1.5, < 1.0',


### PR DESCRIPTION
Remove the checks for naming policy (is_misnamed and unversioned_requirers).
That part is done; if new packages named python-X appear they
better be python3 (which is not cool according to guidelines,
but not a problem worth tracking).

Remove special-casing NAME_NOTS. This means packages like
python-rpm-generators and python-rpm-macros start showing up as
build dependencies (in python3-only green).

The `have_binaries` function from taskotron-python-versions is embedded.

This is preparation for EOLing taskotron-python-versions.

Closes: https://github.com/fedora-python/portingdb/pull/676