### PR TITLE
Require python-bugzilla

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ requires = [
     'blessings >= 1.7, < 2.0',
     'elsa >= 0.1.5, < 1.0',
     'networkx >= 2.2, < 3.0',
+    'python-bugzilla >= 2.5, < 3.0',
 ]
 
 tests_require = ['pytest']


### PR DESCRIPTION
Otherwise you'll get:

    $ PYTHONPATH=. python -m portingdb serve
    Traceback (most recent call last):
      File "/usr/lib64/python3.8/runpy.py", line 194, in _run_module_as_main
        return _run_code(code, main_globals, None,
      File "/usr/lib64/python3.8/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File ".../portingdb/portingdb/__main__.py", line 1, in <module>
        from portingdb.cli import main
      File ".../portingdb/portingdb/cli.py", line 11, in <module>
        from portingdb.check_fti import check_fti
      File ".../portingdb/portingdb/check_fti.py", line 11, in <module>
        import bugzilla
    ModuleNotFoundError: No module named 'bugzilla'